### PR TITLE
Remove the rollback class method

### DIFF
--- a/lib/interactor.rb
+++ b/lib/interactor.rb
@@ -15,10 +15,6 @@ module Interactor
     def perform(context = {})
       new(context).tap(&:perform)
     end
-
-    def rollback(context = {})
-      new(context).tap(&:rollback)
-    end
   end
 
   module InstanceMethods

--- a/spec/support/lint.rb
+++ b/spec/support/lint.rb
@@ -19,24 +19,6 @@ shared_examples :lint do
     end
   end
 
-  describe ".rollback" do
-    let(:instance) { double(:instance) }
-
-    it "rolls back an instance with the given context" do
-      expect(interactor).to receive(:new).once.with(foo: "bar") { instance }
-      expect(instance).to receive(:rollback).once.with(no_args)
-
-      expect(interactor.rollback(foo: "bar")).to eq(instance)
-    end
-
-    it "provides a blank context if none is given" do
-      expect(interactor).to receive(:new).once.with({}) { instance }
-      expect(instance).to receive(:rollback).once.with(no_args)
-
-      expect(interactor.rollback).to eq(instance)
-    end
-  end
-
   describe ".new" do
     let(:context) { double(:context) }
 


### PR DESCRIPTION
Rolling back is now handled internally only, and on the instance.
