### PR TITLE
Don't defer to context for respond_to? until context is set.

### DIFF
--- a/lib/interactor.rb
+++ b/lib/interactor.rb
@@ -47,6 +47,6 @@ module Interactor
   end
 
   def respond_to_missing?(method, *)
-    context.key?(method) || super
+    (context && context.key?(method)) || super
   end
 end

--- a/spec/support/lint.rb
+++ b/spec/support/lint.rb
@@ -127,18 +127,28 @@ shared_examples :lint do
   end
 
   describe "context deferral" do
-    let(:instance) { interactor.new(foo: "bar") }
+    context "initialized" do
+      let(:instance) { interactor.new(foo: "bar") }
 
-    it "defers to keys that exist in the context" do
-      expect(instance).to respond_to(:foo)
-      expect(instance.foo).to eq("bar")
-      expect { instance.method(:foo) }.not_to raise_error
+      it "defers to keys that exist in the context" do
+        expect(instance).to respond_to(:foo)
+        expect(instance.foo).to eq("bar")
+        expect { instance.method(:foo) }.not_to raise_error
+      end
+
+      it "bombs if the key does not exist in the context" do
+        expect(instance).not_to respond_to(:baz)
+        expect { instance.baz }.to raise_error(NoMethodError)
+        expect { instance.method(:baz) }.to raise_error(NameError)
+      end
     end
 
-    it "bombs if the key does not exist in the context" do
-      expect(instance).not_to respond_to(:baz)
-      expect { instance.baz }.to raise_error(NoMethodError)
-      expect { instance.method(:baz) }.to raise_error(NameError)
+    context "allocated" do
+      let(:instance) { interactor.allocate }
+
+      it "doesn't respond to context keys before the context is set" do
+        expect(instance).not_to respond_to(:foo)
+      end
     end
   end
 end


### PR DESCRIPTION
This is keeping interactors from Just Working with delayed_job, as it bombs when deserializing from YAML. YAML calls a respond_to? but because the context isn't set, interactor bombs. 

I want to give YAML a slap, but I'm just trying to do my job here.

![](http://d24w6bsrhbeh9d.cloudfront.net/photo/aBKwZmD_460sa.gif)

I'm happy to take style suggestions, or ideas for a more descriptive test name.
