### PR TITLE
Ensure that context-deferred methods respect string keys

### DIFF
--- a/lib/interactor.rb
+++ b/lib/interactor.rb
@@ -43,10 +43,10 @@ module Interactor
   end
 
   def method_missing(method, *)
-    context.fetch(method) { super }
+    context.fetch(method) { context.fetch(method.to_s) { super } }
   end
 
   def respond_to_missing?(method, *)
-    (context && context.key?(method)) || super
+    (context && (context.key?(method) || context.key?(method.to_s))) || super
   end
 end

--- a/spec/support/lint.rb
+++ b/spec/support/lint.rb
@@ -128,12 +128,18 @@ shared_examples :lint do
 
   describe "context deferral" do
     context "initialized" do
-      let(:instance) { interactor.new(foo: "bar") }
+      let(:instance) { interactor.new(foo: "bar", "hello" => "world") }
 
       it "defers to keys that exist in the context" do
         expect(instance).to respond_to(:foo)
         expect(instance.foo).to eq("bar")
         expect { instance.method(:foo) }.not_to raise_error
+      end
+
+      it "defers to string keys that exist in the context" do
+        expect(instance).to respond_to(:hello)
+        expect(instance.hello).to eq("world")
+        expect { instance.method(:hello) }.not_to raise_error
       end
 
       it "bombs if the key does not exist in the context" do


### PR DESCRIPTION
Fixes this case:

``` ruby
interactor = MyInteractor("foo" => "bar")
interactor.foo # => nil
interactor.context[:foo] # => nil
interactor.context["foo"] # => "bar"
```
