### PR TITLE
Patch Psych to deserialize simple delegators (contexts) properly

### DIFF
--- a/lib/interactor/context.rb
+++ b/lib/interactor/context.rb
@@ -24,3 +24,9 @@ module Interactor
     end
   end
 end
+
+require "yaml"
+
+Psych::Visitors::YAMLTree.class_eval do
+  alias_method :visit_Delegator, :visit_Object
+end

--- a/spec/support/lint.rb
+++ b/spec/support/lint.rb
@@ -157,4 +157,26 @@ shared_examples :lint do
       end
     end
   end
+
+  describe "YAML serialization" do
+    require "yaml"
+
+    let(:instance) { interactor.new(foo: "bar") }
+
+    before do
+      # Give the interactor class a name for proper YAML deserialization
+      Object.send(:remove_const, :LintInteractor) if Object.const_defined?(:LintInteractor)
+      Object.const_set(:LintInteractor, interactor)
+    end
+
+    it "is serializable and deserializable" do
+      expect { YAML.load(YAML.dump(instance)) }.not_to raise_error
+    end
+
+    it "preserves its context" do
+      instance2 = YAML.load(YAML.dump(instance))
+
+      expect(instance2.context).to eq(instance.context)
+    end
+  end
 end


### PR DESCRIPTION
:warning: Work in progress!

I'm not sure about requiring YAML to load the `Interactor::Context` class. What are the downfalls? Is there a better way?
