### PR TITLE
Add success! to context

### DIFF
--- a/lib/interactor/context.rb
+++ b/lib/interactor/context.rb
@@ -22,5 +22,10 @@ module Interactor
       update(context)
       @failure = true
     end
+
+    def success!(context = {})
+      update(context)
+      @failure = false
+    end
   end
 end

--- a/spec/interactor/context_spec.rb
+++ b/spec/interactor/context_spec.rb
@@ -122,5 +122,43 @@ module Interactor
         }.from("bar").to("baz")
       end
     end
+
+    describe "#success!" do
+      let(:context) { Context.build(foo: "bar") }
+
+      it "preserves success" do
+        expect {
+          context.success!
+        }.not_to change {
+          context.success?
+        }
+      end
+
+      it "changes failure to success" do
+        context.fail!
+
+        expect {
+          context.success!
+        }.to change {
+          context.success?
+        }.from(false).to(true)
+      end
+
+      it "preserves the context" do
+        expect {
+          context.success!
+        }.not_to change {
+          context[:foo]
+        }
+      end
+
+      it "updates the context" do
+        expect {
+          context.success!(foo: "baz")
+        }.to change {
+          context[:foo]
+        }.from("bar").to("baz")
+      end
+    end
   end
 end


### PR DESCRIPTION
I like being able to call fail! and pass in my failure message, I would like to do the same with success!

``` ruby
class MarkOrderShipped
  include Interactor

  def perform
    if order.shipped_at.present?
      fail!(error: 'Order has already been marked as shipped')
    else
      order.shipped_at = Time.zone.now
      order.save!
      OrderMailer.ship_confirmation(order.id).deliver
      # context[:notice] = "#{order.number} marked as shipped, #{order.customer.email} has been notified."
      success!(notice: "#{order.number} marked as shipped, #{order.customer.email} has been notified.")
    end
  end
end
```
