### PR TITLE
Build interactors with a block

### DIFF
--- a/lib/interactor.rb
+++ b/lib/interactor.rb
@@ -50,3 +50,10 @@ module Interactor
     (context && (context.key?(method) || context.key?(method.to_s))) || super
   end
 end
+
+def Interactor(&block)
+  Class.new.tap do |interactor|
+    interactor.send :include, Interactor
+    interactor.send :define_method, :perform, &block
+  end
+end

--- a/spec/interactor_spec.rb
+++ b/spec/interactor_spec.rb
@@ -3,3 +3,19 @@ require "spec_helper"
 describe Interactor do
   include_examples :lint
 end
+
+describe "Interactor()" do
+  it "builds a class that includes Interactor" do
+    interactor = Interactor{ }
+
+    expect(interactor).to be_a(Class)
+    expect(interactor).to include(Interactor)
+  end
+
+  it "defines the new class perform method using the given block" do
+    interactor = Interactor{ context[:check] = true }
+    result = interactor.perform
+
+    expect(result.check).to be_true
+  end
+end


### PR DESCRIPTION
I looked at the issue about using #call instead of #perform (#27) and thought it would work to have a builder function.

``` ruby
interactor = Interactor do
  # do something
end

interactor.perform
```
