### PR TITLE
Change Interactor.call to return the context rather than the instance

### DIFF
--- a/lib/interactor.rb
+++ b/lib/interactor.rb
@@ -12,9 +12,16 @@ module Interactor
 
   module ClassMethods
     def call(context = {})
-      new(context).tap do |instance|
-        instance.call unless instance.context.failure?
-      end
+      instance = new(context)
+      context = instance.context
+      instance.call unless context.failure?
+      context
+    end
+
+    def rollback(context = {})
+      instance = new(context)
+      instance.rollback
+      instance.context
     end
   end
 

--- a/lib/interactor/organizer.rb
+++ b/lib/interactor/organizer.rb
@@ -27,19 +27,27 @@ module Interactor
       def call
         interactors.each do |interactor|
           begin
-            instance = interactor.call(context)
+            interactor.call(context)
           rescue
-            rollback
+            rollback_called
             raise
           end
 
-          rollback && break if context.failure?
-          called << instance
+          rollback_called && break if context.failure?
+          called << interactor
         end
       end
 
       def rollback
-        called.reverse_each(&:rollback)
+        interactors.reverse_each do |interactor|
+          interactor.rollback(context)
+        end
+      end
+
+      def rollback_called
+        called.reverse_each do |interactor|
+          interactor.rollback(context)
+        end
       end
 
       def called

--- a/spec/support/lint.rb
+++ b/spec/support/lint.rb
@@ -11,14 +11,14 @@ shared_examples :lint do
         expect(interactor).to receive(:new).once.with(foo: "bar") { instance }
         expect(instance).to receive(:call).once.with(no_args)
 
-        expect(interactor.call(foo: "bar")).to eq(instance)
+        expect(interactor.call(foo: "bar")).to eq(context)
       end
 
       it "provides a blank context if none is given" do
         expect(interactor).to receive(:new).once.with({}) { instance }
         expect(instance).to receive(:call).once.with(no_args)
 
-        expect(interactor.call).to eq(instance)
+        expect(interactor.call).to eq(context)
       end
     end
 
@@ -31,8 +31,27 @@ shared_examples :lint do
 
         expect(instance).not_to receive(:call)
 
-        expect(interactor.call).to eq(instance)
+        expect(interactor.call).to eq(context)
       end
+    end
+  end
+
+  describe ".rollback" do
+    let(:context) { double(:context) }
+    let(:instance) { double(:instance, context: context) }
+
+    it "rolls back an instance with the given context" do
+      expect(interactor).to receive(:new).once.with(foo: "bar") { instance }
+      expect(instance).to receive(:rollback).once.with(no_args)
+
+      expect(interactor.rollback(foo: "bar")).to eq(context)
+    end
+
+    it "provides a blank context if none is given" do
+      expect(interactor).to receive(:new).once.with({}) { instance }
+      expect(instance).to receive(:rollback).once.with(no_args)
+
+      expect(interactor.rollback).to eq(context)
     end
   end
 


### PR DESCRIPTION
References: #49
