### PR TITLE
Implements around hooks

### DIFF
--- a/lib/interactor/hooks.rb
+++ b/lib/interactor/hooks.rb
@@ -10,6 +10,51 @@ module Interactor
 
     # Internal: Interactor::Hooks class methods.
     module ClassMethods
+
+      # Public: Declare hooks to run around Interactor invocation. The around
+      # method may be called multiple times; subsequent calls append declared
+      # hooks to existing around hooks.
+      # 
+      # Blocks or methods passed to the around method are responsible for invoking
+      # the interactor by calling the method run!.
+      #
+      # hooks - Zero or more Symbol method names representing instance methods
+      #         to be called around interactor invocation.
+      # block - An optional block to be executed as a hook. If given, the block
+      #         is executed after methods corresponding to any given Symbols.
+      #
+      # Examples
+      #
+      #   class MyInteractor
+      #     include Interactor
+      #
+      #     around :time_action
+      #
+      #     around do
+      #       puts "hello"
+      #       run!
+      #       puts "goodbye"
+      #     end
+      #
+      #     def call
+      #       puts "called"
+      #     end
+      #
+      #     private
+      #
+      #     def time_action
+      #       start_time = Time.now
+      #       run!
+      #       end_time = Time.now
+      #     end
+      #   end
+      #
+      # Returns nothing.
+      def around(*hooks, &block)
+        hooks << block if block
+        hooks.each { |hook| around_hooks.push(hook) }
+      end
+
       # Public: Declare hooks to run before Interactor invocation. The before
       # method may be called multiple times; subsequent calls append declared
       # hooks to existing before hooks.
@@ -84,6 +129,25 @@ module Interactor
         hooks.each { |hook| after_hooks.unshift(hook) }
       end
 
+      # Internal: An Array of declared hooks to run around the Interactor
+      # invocation. The hooks appear in the order in which they will be run.
+      #
+      # Examples
+      #
+      #   class MyInteractor
+      #     include Interactor
+      #
+      #     around :time_action, :say_hello_and_goodbye
+      #   end
+      #
+      #   MyInteractor.around_hooks
+      #   # => [:time_action, :say_hello_and_goodbye]
+      #
+      # Returns an Array of Symbols and Procs.
+      def around_hooks
+        @around_hooks ||= []
+      end
+
       # Internal: An Array of declared hooks to run before Interactor
       # invocation. The hooks appear in the order in which they will be run.
       #
@@ -125,7 +189,7 @@ module Interactor
 
     private
 
-    # Internal: Run before and after hooks around yielded execution. The
+    # Internal: Run around, before and after hooks encompassing yielded execution. The
     # required block is surrounded with hooks and executed.
     #
     # Examples
@@ -146,9 +210,23 @@ module Interactor
     #
     # Returns nothing.
     def with_hooks
-      run_before_hooks
-      yield
-      run_after_hooks
+      run_around_hooks do
+        run_before_hooks
+        yield
+        run_after_hooks
+      end
+    end
+
+    # Internal: Run around hooks recursively.
+    #
+    # Returns nothing.
+    def run_around_hooks(&block)
+      hook = self.class.around_hooks.shift
+      if hook
+        run_hook(hook)
+      else
+        yield
+      end
     end
 
     # Internal: Run before hooks.

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -16,16 +16,18 @@ describe "Integration" do
   #  ├─ organizer2
   #  │   ├─ interactor2a
   #  │   ├─ interactor2b
-  #  │   └─ interactor2c
+  #  │   ├─ interactor2c
+  #  │   └─ interactor2d
   #  ├─ interactor3
   #  ├─ organizer4
   #  │   ├─ interactor4a
   #  │   ├─ interactor4b
   #  │   └─ interactor4c
-  #  └─ interactor5
+  #  ├─ interactor5
+  #  └─ interactor6
 
   let(:organizer) {
-    build_organizer(organize: [organizer2, interactor3, organizer4, interactor5]) do
+    build_organizer(organize: [organizer2, interactor3, organizer4, interactor5, interactor6]) do
       before do
         context.steps << :before
       end
@@ -37,7 +39,7 @@ describe "Integration" do
   }
 
   let(:organizer2) {
-    build_organizer(organize: [interactor2a, interactor2b, interactor2c]) do
+    build_organizer(organize: [interactor2a, interactor2b, interactor2c, interactor2d]) do
       before do
         context.steps << :before2
       end
@@ -104,6 +106,22 @@ describe "Integration" do
 
       def rollback
         context.steps << :rollback2c
+      end
+    end
+  }
+
+  let(:interactor2d) {
+    build_interactor do
+      around :around_method
+
+      def call
+        context.steps << :call2d
+      end
+
+      def around_method
+        context.steps << :around_before2d
+        run!
+        context.steps << :around_after2d
       end
     end
   }
@@ -220,6 +238,34 @@ describe "Integration" do
     end
   }
 
+  let(:interactor6) {
+    build_interactor do
+      around :around_method6
+      
+      around do
+        context.steps << :around_before6b
+        run!
+        context.steps << :around_after6b
+      end
+
+      around do
+        context.steps << :around_before6b2
+        run!
+        context.steps << :around_after6b2
+      end
+
+      def call
+        context.steps << :call6
+      end
+
+      def around_method6
+        context.steps << :around_before6m
+        run!
+        context.steps << :around_after6m
+      end
+    end
+  }
+
   let(:context) { Interactor::Context.build(steps: []) }
 
   context "when successful" do
@@ -234,6 +280,7 @@ describe "Integration" do
             :before2a, :call2a, :after2a,
             :before2b, :call2b, :after2b,
             :before2c, :call2c, :after2c,
+            :around_before2d, :call2d, :around_after2d,
           :after2,
           :before3, :call3, :after3,
           :before4,
@@ -242,6 +289,7 @@ describe "Integration" do
             :before4c, :call4c, :after4c,
           :after4,
           :before5, :call5, :after5,
+          :around_before6m, :around_before6b, :around_before6b2, :call6, :around_after6b2, :around_after6b, :around_after6m,
         :after
       ])
     end
@@ -324,6 +372,7 @@ describe "Integration" do
             :before2a, :call2a, :after2a,
             :before2b, :call2b, :after2b,
             :before2c, :call2c, :after2c,
+            :around_before2d, :call2d, :around_after2d,
           :after2,
           :before3, :call3, :after3,
           :before4,
@@ -369,6 +418,7 @@ describe "Integration" do
             :before2a, :call2a, :after2a,
             :before2b, :call2b, :after2b,
             :before2c, :call2c, :after2c,
+            :around_before2d, :call2d, :around_after2d,
           :after2,
           :before3, :call3, :after3,
           :before4,
@@ -428,6 +478,7 @@ describe "Integration" do
             :before2a, :call2a, :after2a,
             :before2b, :call2b, :after2b,
             :before2c, :call2c, :after2c,
+            :around_before2d, :call2d, :around_after2d,
           :after2,
         :rollback2c,
         :rollback2b,
@@ -469,6 +520,7 @@ describe "Integration" do
             :before2a, :call2a, :after2a,
             :before2b, :call2b, :after2b,
             :before2c, :call2c, :after2c,
+            :around_before2d, :call2d, :around_after2d,
           :after2,
         :rollback2c,
         :rollback2b,
@@ -516,6 +568,7 @@ describe "Integration" do
             :before2a, :call2a, :after2a,
             :before2b, :call2b, :after2b,
             :before2c, :call2c, :after2c,
+            :around_before2d, :call2d, :around_after2d,
           :after2,
           :before3,
         :rollback2c,
@@ -558,6 +611,7 @@ describe "Integration" do
             :before2a, :call2a, :after2a,
             :before2b, :call2b, :after2b,
             :before2c, :call2c, :after2c,
+            :around_before2d, :call2d, :around_after2d,
           :after2,
           :before3,
         :rollback2c,
@@ -606,6 +660,7 @@ describe "Integration" do
             :before2a, :call2a, :after2a,
             :before2b, :call2b, :after2b,
             :before2c, :call2c, :after2c,
+            :around_before2d, :call2d, :around_after2d,
           :after2,
           :before3, :call3,
         :rollback3,
@@ -649,6 +704,7 @@ describe "Integration" do
             :before2a, :call2a, :after2a,
             :before2b, :call2b, :after2b,
             :before2c, :call2c, :after2c,
+            :around_before2d, :call2d, :around_after2d,
           :after2,
           :before3, :call3,
         :rollback3,
@@ -698,6 +754,7 @@ describe "Integration" do
             :before2a, :call2a, :after2a,
             :before2b, :call2b, :after2b,
             :before2c, :call2c, :after2c,
+            :around_before2d, :call2d, :around_after2d,
           :after2,
           :before3, :call3, :after3,
           :before4,
@@ -744,6 +801,7 @@ describe "Integration" do
             :before2a, :call2a, :after2a,
             :before2b, :call2b, :after2b,
             :before2c, :call2c, :after2c,
+            :around_before2d, :call2d, :around_after2d,
           :after2,
           :before3, :call3, :after3,
           :before4,
@@ -796,6 +854,7 @@ describe "Integration" do
             :before2a, :call2a, :after2a,
             :before2b, :call2b, :after2b,
             :before2c, :call2c, :after2c,
+            :around_before2d, :call2d, :around_after2d,
           :after2,
           :before3, :call3, :after3,
           :before4,
@@ -843,6 +902,7 @@ describe "Integration" do
             :before2a, :call2a, :after2a,
             :before2b, :call2b, :after2b,
             :before2c, :call2c, :after2c,
+            :around_before2d, :call2d, :around_after2d,
           :after2,
           :before3, :call3, :after3,
           :before4,
@@ -896,6 +956,7 @@ describe "Integration" do
             :before2a, :call2a, :after2a,
             :before2b, :call2b, :after2b,
             :before2c, :call2c, :after2c,
+            :around_before2d, :call2d, :around_after2d,
           :after2,
           :before3, :call3, :after3,
           :before4,
@@ -944,6 +1005,7 @@ describe "Integration" do
             :before2a, :call2a, :after2a,
             :before2b, :call2b, :after2b,
             :before2c, :call2c, :after2c,
+            :around_before2d, :call2d, :around_after2d,
           :after2,
           :before3, :call3, :after3,
           :before4,


### PR DESCRIPTION
Implements around hooks following the discussion at #50, heavily inspired by RSpec. Around blocks or methods must call the run! method because too many blocks are being passed around that need to be run on the interactor instance context.

Mandatory animated gif: 
![](https://d324imu86q1bqn.cloudfront.net/uploads/asset/attachment/360140/raposinhasapeca1.gif)

CC: @brunnogomes and @gvc
