### PR TITLE
Update the README testing example to one that works

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,7 +510,7 @@ describe AuthenticateUser do
       it { is_expected.to be_a_failure }
 
       it "provides a failure message" do
-        expect(subject.message).to_not be_present
+        expect(subject.message).to be_present
       end
     end
   end

--- a/README.md
+++ b/README.md
@@ -482,9 +482,7 @@ context.
 ```ruby
 describe AuthenticateUser do
   describe "#call" do
-
-    let(:interactor) { AuthenticateUser.new(email: "john@example.com", password: "secret") }
-    let(:context) { interactor.context }
+    subject(:context) { AuthenticateUser.call(email: "john@example.com", password: "secret") }
 
     context "when given valid credentials" do
       let(:user) { double(:user, secret_token: "token") }
@@ -493,26 +491,14 @@ describe AuthenticateUser do
         allow(User).to receive(:authenticate).with("john@example.com", "secret").and_return(user)
       end
 
-      it "succeeds" do
-        interactor.call
-
-        expect(context).to be_a_success
-      end
+      it { is_expected.to be_a_success }
 
       it "provides the user" do
-        expect {
-          interactor.call
-        }.to change {
-          context.user
-        }.from(nil).to(user)
+        expect(subject.user).to eq(user)
       end
 
       it "provides the user's secret token" do
-        expect {
-          interactor.call
-        }.to change {
-          context.token
-        }.from(nil).to("token")
+        expect(subject.token).to eq("token")
       end
     end
 
@@ -521,18 +507,10 @@ describe AuthenticateUser do
         allow(User).to receive(:authenticate).with("john@example.com", "secret").and_return(nil)
       end
 
-      it "fails" do
-        interactor.call
-
-        expect(context).to be_a_failure
-      end
+      it { is_expected.to be_a_failure }
 
       it "provides a failure message" do
-        expect {
-          interactor.call
-        }.to change {
-          context.message
-        }.from(nil).to be_present
+        expect(subject.message).to_not be_present
       end
     end
   end

--- a/spec/readme_spec.rb
+++ b/spec/readme_spec.rb
@@ -1,0 +1,73 @@
+class AuthenticateUser
+  include Interactor
+
+  def call
+    if user = User.authenticate(context.email, context.password)
+      context.user = user
+      context.token = user.secret_token
+    else
+      context.fail!(message: "authenticate_user.failure")
+    end
+  end
+end
+
+class User; end
+
+describe "The testing example from the README" do
+  describe AuthenticateUser do
+    describe "#call" do
+      let(:interactor) { AuthenticateUser.new(email: "john@example.com", password: "secret") }
+      let(:context) { interactor.context }
+
+      context "when given valid credentials" do
+        let(:user) { double(:user, secret_token: "token") }
+
+        before do
+          allow(User).to receive(:authenticate).with("john@example.com", "secret").and_return(user)
+        end
+
+        it "succeeds" do
+          interactor.call
+
+          expect(context).to be_a_success
+        end
+
+        it "provides the user" do
+          expect {
+            interactor.call
+          }.to change {
+            context.user
+          }.from(nil).to(user)
+        end
+
+        it "provides the user's secret token" do
+          expect {
+            interactor.call
+          }.to change {
+            context.token
+          }.from(nil).to("token")
+        end
+      end
+
+      context "when given invalid credentials" do
+        before do
+          allow(User).to receive(:authenticate).with("john@example.com", "secret").and_return(nil)
+        end
+
+        it "fails" do
+          interactor.call
+
+          expect(context).to be_a_failure
+        end
+
+        it "provides a failure message" do
+          expect {
+            interactor.call
+          }.to change {
+            context.message
+          }.from(nil).to be_present
+        end
+      end
+    end
+  end
+end

--- a/spec/readme_spec.rb
+++ b/spec/readme_spec.rb
@@ -16,8 +16,7 @@ class User; end
 describe "The testing example from the README" do
   describe AuthenticateUser do
     describe "#call" do
-      let(:interactor) { AuthenticateUser.new(email: "john@example.com", password: "secret") }
-      let(:context) { interactor.context }
+      subject(:context) { AuthenticateUser.call(email: "john@example.com", password: "secret") }
 
       context "when given valid credentials" do
         let(:user) { double(:user, secret_token: "token") }
@@ -26,26 +25,14 @@ describe "The testing example from the README" do
           allow(User).to receive(:authenticate).with("john@example.com", "secret").and_return(user)
         end
 
-        it "succeeds" do
-          interactor.call
-
-          expect(context).to be_a_success
-        end
+        it { is_expected.to be_a_success }
 
         it "provides the user" do
-          expect {
-            interactor.call
-          }.to change {
-            context.user
-          }.from(nil).to(user)
+          expect(subject.user).to eq(user)
         end
 
         it "provides the user's secret token" do
-          expect {
-            interactor.call
-          }.to change {
-            context.token
-          }.from(nil).to("token")
+          expect(subject.token).to eq("token")
         end
       end
 
@@ -54,18 +41,10 @@ describe "The testing example from the README" do
           allow(User).to receive(:authenticate).with("john@example.com", "secret").and_return(nil)
         end
 
-        it "fails" do
-          interactor.call
-
-          expect(context).to be_a_failure
-        end
+        it { is_expected.to be_a_failure }
 
         it "provides a failure message" do
-          expect {
-            interactor.call
-          }.to change {
-            context.message
-          }.from(nil).to be_present
+          expect(subject.message).to_not be_nil  # be_present requires activesupport
         end
       end
     end


### PR DESCRIPTION
The example of how to testing Interactors in the README does not work in
the current version of `interactor`. This is a huge barrier to entry for
anyone looking to use the library. We should update the README to
indicate how tests should actually be done.

Note: This commit is just intended to add the spec to show that it
fails. I will add a second commit in a moment to show the method that
I use to test my Interactors.