### PR TITLE
Changed interactor.call to interactor.run in test documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -522,14 +522,14 @@ describe AuthenticateUser do
       end
 
       it "fails" do
-        interactor.call
+        interactor.run
 
         expect(context).to be_a_failure
       end
 
       it "provides a failure message" do
         expect {
-          interactor.call
+          interactor.run
         }.to change {
           context.message
         }.from(nil).to be_present


### PR DESCRIPTION
Using the method #call causes #fail! to raise an exception which prevents the example tests from working. Using #run rescues the exception and allows you to run expectations on the resulting context.
[ci skip]