### PR TITLE
fail! and exceptions, with and without `call`

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,16 @@ context.fail!
 context.success? # => false
 ```
 
+#### Dealing with Failure
+
+`context.fail!` always throws an exception of type `Interactor::Failure`.
+
+Normally, however, these exceptions are not seen. In the recommended usage, the controller invokes the interactor using the class method `call`, then checks the `success?` method of the context.
+
+This works because the `call` class method swallows exceptions.  When unit testing an interactor, if calling custom business logic methods directly and bypassing `call`, be aware that `fail!` will generate such exceptions.
+
+See *Interactors in the Controller*, below, for the recommended usage of `call` and `success?`.
+
 ### Hooks
 
 #### Before Hooks


### PR DESCRIPTION
[ci skip]
Added text about exceptions thrown by `context.fail!`, and swallowing of exceptions by `call`.  

I believe it's important to have this information near the existing section about `fail!`; the code samples already there don't make it clear that an exception is thrown in the middle of each.

thanks
