### PR TITLE
When calling call! from another interactor merge context on failure

### DIFF
--- a/lib/interactor.rb
+++ b/lib/interactor.rb
@@ -113,7 +113,8 @@ module Interactor
   # Returns nothing.
   def run
     run!
-  rescue Failure
+  rescue Failure => failure
+    context.fail(failure.context || {})
   end
 
   # Internal: Invoke an Interactor instance along with all defined hooks. The

--- a/lib/interactor/context.rb
+++ b/lib/interactor/context.rb
@@ -121,9 +121,17 @@ module Interactor
     #
     # Raises Interactor::Failure initialized with the Interactor::Context.
     def fail!(context = {})
+      fail(context)
+      raise Failure, self
+    end
+
+    def fail(context = {})
       modifiable.update(context)
       @failure = true
-      raise Failure, self
+    end
+
+    def to_hash
+      modifiable
     end
 
     # Internal: Track that an Interactor has been called. The "called!" method

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -1738,4 +1738,26 @@ describe "Integration" do
       }.to raise_error("foo")
     end
   end
+
+  context "when one interactor calls another" do
+    class First
+      include Interactor
+      def call
+        Second.call!
+      end
+    end
+
+    class Second
+      include Interactor
+      def call
+        context.fail!(foo: :bar)
+      end
+    end
+
+    it "updates first context after fail" do
+      result = First.call
+      expect(result).to be_failure
+      expect(result.foo).to eq :bar
+    end
+  end
 end


### PR DESCRIPTION
Wanted to get an idea if something like this would be an acceptable change.

Basically, I would like to use an `Interactor` and do some extra work if the called `Interactor` is successful. Having `call!` update the calling context when `Interactor::Failure` is called makes this much cleaner. For example before you would write,

``` ruby
class Old
  include Interactor

  def call
    # do work
    result = Other.call
    if result.success?
      # do more work
    else
      context.fail!(...)
    end
  end
end
```

Now you do not have to check if the call was successful.

``` ruby
class New
  include Interactor

  def call
    # do work
    Other.call!
    # do more work
  end
end
```

Maybe this can be done in `Organizer`s?
