### PR TITLE
Changes pre-interactor controller action to redirect to root

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ class SessionsController < ApplicationController
   def create
     if user = User.authenticate(session_params[:email], session_params[:password])
       session[:user_token] = user.secret_token
-      redirect_to user
+      redirect_to root_path
     else
       flash.now[:message] = "Please try again."
       render :new


### PR DESCRIPTION
Behavior is in alignment with the rest of the examples which show the redirect going to root instead of to users#show upon successful authentication.

[ci skip]
