### PR TITLE
Fixed Context#fail! to accept context updates in a hash with string keys

### DIFF
--- a/lib/interactor/context.rb
+++ b/lib/interactor/context.rb
@@ -121,7 +121,11 @@ module Interactor
     #
     # Raises Interactor::Failure initialized with the Interactor::Context.
     def fail!(context = {})
-      modifiable.update(context)
+      symbolized_context = {}
+      context.each do |k, v|
+        symbolized_context[k.to_sym] = v
+      end
+      modifiable.update(symbolized_context)
       @failure = true
       raise Failure, self
     end

--- a/spec/interactor/context_spec.rb
+++ b/spec/interactor/context_spec.rb
@@ -101,6 +101,14 @@ module Interactor
         }.from("bar").to("baz")
       end
 
+      it "updates the context with a string key" do
+        expect {
+          context.fail!("foo" => "baz") rescue nil
+        }.to change {
+          context.foo
+        }.from("bar").to("baz")
+      end
+
       it "raises failure" do
         expect {
           context.fail!


### PR DESCRIPTION
Context is initialized by a hash. Internally it's implemented by OpenStruct which takes care of handling string/symbol keys. `Context#fail!` takes an optional hash of context updates which assumes all keys are symbols. Not a big problem but a small inconsistency. This change converts all keys to symbols before updating the context.

![](http://i.imgur.com/MBZP7HY.gif)
