### PR TITLE
Adds Organizer halting for non-failure breaks in interactor chain

### DIFF
--- a/lib/interactor.rb
+++ b/lib/interactor.rb
@@ -143,7 +143,9 @@ module Interactor
       call
       context.called!(self)
     end
-  rescue
+  rescue Halt => e # allow stopping of organizer
+    raise
+  rescue # rescue everything else
     context.rollback!
     raise
   end

--- a/lib/interactor/context.rb
+++ b/lib/interactor/context.rb
@@ -126,6 +126,33 @@ module Interactor
       raise Failure, self
     end
 
+    # Public: Halt the Interactor::Context. Halting a context allows stopping the
+    # context without failing it. It is often used in stopping Organizer chains
+    # without explicitly failing. The context is not flagged as having failed.
+    #
+    # Optionally the caller may provide a hash of key/value pairs to be merged
+    # into the context before halting.
+    #
+    # context - A Hash whose key/value pairs are merged into the existing
+    #           Interactor::Context instance. (default: {})
+    #
+    # Examples
+    #
+    #   context = Interactor::Context.new
+    #   # => #<Interactor::Context>
+    #   context.halt!
+    #   # => Interactor::Halt: #<Interactor::Context>
+    #   context.halt! rescue false
+    #   # => false
+    #   context.halt!(foo: "baz")
+    #   # => Interactor::Halt: #<Interactor::Context foo="baz">
+    #
+    # Raises Interactor::Halt initialized with the Interactor::Context.
+    def halt!(context = {})
+      modifiable.update(context)
+      raise Halt, self
+    end
+
     # Internal: Track that an Interactor has been called. The "called!" method
     # is used by the interactor being invoked with this context. After an
     # interactor is successfully called, the interactor instance is tracked in

--- a/lib/interactor/error.rb
+++ b/lib/interactor/error.rb
@@ -28,4 +28,9 @@ module Interactor
       super
     end
   end
+
+  # Internal: Organizer halting error raised during Interactor::Context halt.
+  # The error stores a copy of the halted context for debugging purposes.
+  class Halt < Failure
+  end
 end

--- a/lib/interactor/organizer.rb
+++ b/lib/interactor/organizer.rb
@@ -78,6 +78,8 @@ module Interactor
         self.class.organized.each do |interactor|
           interactor.call!(context)
         end
+      rescue Halt # we want to stop the organizer, but not explicitly fail
+        nil
       end
     end
   end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -1738,4 +1738,49 @@ describe "Integration" do
       }.to raise_error("foo")
     end
   end
+
+
+  context "when a nested call halts" do
+    let(:interactor3) {
+      build_interactor do
+        around do |interactor|
+          context.steps << :around_before3
+          interactor.call
+          context.steps << :around_after3
+        end
+
+        before do
+          context.steps << :before3
+        end
+
+        after do
+          context.steps << :after3
+        end
+
+        def call
+          raise Interactor::Halt, error: "foo"
+          context.steps << :call3
+        end
+
+        def rollback
+          context.steps << :rollback3
+        end
+      end
+    }
+
+    it "ends but does not rollback called interactors" do
+      expect {
+        organizer.call(context) rescue nil
+      }.to change(context, :steps).from([]).to([
+        :around_before, :before,
+        :around_before2, :before2,
+        :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
+        :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
+        :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
+        :after2, :around_after2,
+        :around_before3, :before3,
+        :after, :around_after
+      ])
+    end
+  end
 end

--- a/spec/interactor/context_spec.rb
+++ b/spec/interactor/context_spec.rb
@@ -116,6 +116,60 @@ module Interactor
       end
     end
 
+    describe "#halt!" do
+      let(:context) { Context.build(foo: "bar") }
+
+      it "sets success to true" do
+        context.halt! rescue nil
+        expect(context).to be_a_success
+      end
+
+      it "sets failure to false" do
+        context.halt! rescue nil
+        expect(context).to_not be_a_failure
+      end
+
+      it "preserves failure" do
+        context.fail! rescue nil
+
+        expect {
+          context.halt! rescue nil
+        }.not_to change {
+                   context.failure?
+                 }
+      end
+
+      it "preserves the context" do
+        expect {
+          context.halt! rescue nil
+        }.not_to change {
+                   context.foo
+                 }
+      end
+
+      it "updates the context" do
+        expect {
+          context.halt!(foo: "baz") rescue nil
+        }.to change {
+               context.foo
+             }.from("bar").to("baz")
+      end
+
+      it "to raise a Halt failure" do
+        expect {
+          context.halt!
+        }.to raise_error(Halt)
+      end
+
+      it "makes the context available from the failure" do
+        begin
+          context.halt!
+        rescue Halt => error
+          expect(error.context).to eq(context)
+        end
+      end
+    end
+
     describe "#called!" do
       let(:context) { Context.build }
       let(:instance1) { double(:instance1) }

--- a/spec/interactor/organizer_spec.rb
+++ b/spec/interactor/organizer_spec.rb
@@ -53,5 +53,29 @@ module Interactor
         instance.call
       end
     end
+
+    describe 'halting in a chain' do
+      let(:instance) { organizer.new }
+      let(:context) { double(:context) }
+      let(:interactor2) { double(:interactor2) }
+      let(:interactor3) { double(:interactor3) }
+      let(:interactor4) { double(:interactor4) }
+
+      before do
+        allow(instance).to receive(:context) { context }
+        allow(organizer).to receive(:organized) {
+                              [interactor2, interactor3, interactor4]
+                            }
+      end
+
+      it 'halts and does not call the latter' do
+        expect(interactor2).to receive(:call!).once.with(context).ordered
+        expect(interactor3).to receive(:call!).once.with(context).ordered.and_raise(Halt)
+        expect(interactor4).to_not receive(:call!)
+
+        instance.call
+      end
+
+    end
   end
 end


### PR DESCRIPTION
Adds the ability to `halt!` within an Interactor, which stops the interactor, but when within an Organizer, does not execute rollbacks.

This is useful in the scenario that you have built an organizer, but do not want it to proceed in the interactor chain in certain conditions. However, you do _not_ necessarily want it to `fail!`, as that implies an error - these cases are for success cases that demand early termination.

Consider the following:

```
class A
  include Interactor::Organizer
  organize B, C, D
end

class B
  include Interactor
  def call; end
end

class C
  include Interactor
  def call
    context.halt!(message: "Stopping prematurely")
  end
end

class D
  include Interactor
  def call
    context.message "It will never get here."
  end
end
```

Then calling:

```
result = A.call # calls B, then C, but never gets to D
puts result.message if result.success? # => "Stopping prematurely"
```
