### PR TITLE
Adds a test helper for mocking Organizers in RSpec

### DIFF
--- a/README.md
+++ b/README.md
@@ -523,7 +523,38 @@ end
 
 [We](http://collectiveidea.com) use RSpec but the same approach applies to any
 testing framework.
+## Testing Organizers
 
+If you're using RSpec, there's a helper method called `mock_organizer` that
+you can use to simplify your Organizer specs.
+
+To use the helper you must require
+
+`require "interactor/test_helpers"` in your `spec_helper.rb`
+
+The spec would then look something like this --
+
+```ruby
+RSpec.describe ExampleOrganizer do
+  include Interactor::TestHelpers
+
+  before(:example) do
+    mock_organizer(ExampleOrganizer)
+  end
+
+  describe ".call" do
+    it "calls FirstInteractor" do
+      expect(FirstInteractor).to receive(:call!)
+      ExampleOrganizer.call
+    end
+
+    it "calls SecondInteractor" do
+      expect(SecondInteractor).to receive(:call!)
+      ExampleOrganizer.call
+    end
+  end
+end
+```
 ### Isolation
 
 You may notice that we stub `User.authenticate` in our test rather than creating

--- a/lib/interactor/test_helpers.rb
+++ b/lib/interactor/test_helpers.rb
@@ -1,0 +1,43 @@
+include RSpec::Mocks::ExampleMethods
+
+module Interactor
+  # Public: Interactor::TestHelpers methods.
+  #
+  # Examples:
+  #
+  #   RSpec.describe ExampleOrganizer do
+  #     include Interactor::TestHelpers
+  #     ...
+  #   end
+  module TestHelpers
+    # Public: Stub all Interactors organized by an Organizer.
+    #
+    # Examples:
+    #
+    #   before(:example) do
+    #     mock_organizer(ExampleOrganizer)
+    #   end
+    #
+    #   describe ".call" do
+    #     it "calls FirstInteractor" do
+    #       expect(FirstInteractor).to receive(:call!)
+    #       ExampleOrganizer.call
+    #     end
+    #
+    #     it "calls SecondInteractor" do
+    #       expect(SecondInteractor).to receive(:call!)
+    #       ExampleOrganizer.call
+    #     end
+    #   end
+    def mock_organizer(organizer)
+      organizer.organized.each do |interactor|
+        instance = double("#{interactor}")
+
+        allow(interactor).to receive(:new).and_return(instance)
+        allow(instance).to receive(:run!)
+        allow(instance).to receive(:run)
+        allow(instance).to receive(:context)
+      end
+    end
+  end
+end

--- a/spec/interactor/test_helpers_spec.rb
+++ b/spec/interactor/test_helpers_spec.rb
@@ -1,0 +1,36 @@
+include Interactor::TestHelpers
+
+module Interactor
+  describe TestHelpers do
+    let(:organizer)   { Class.new.send(:include, Organizer) }
+    let(:interactor1) { Class.new.send(:include, Interactor) }
+    let(:interactor2) { Class.new.send(:include, Interactor) }
+    let(:interactor3) { Class.new.send(:include, Interactor) }
+
+    before do
+      organizer.organize([interactor1, interactor2, interactor3])
+    end
+
+    describe ".mock_organizer" do
+      it "initializes a context for each interactor" do
+        mock_organizer(organizer)
+
+        expect(interactor1).to receive(:new)
+        expect(interactor2).to receive(:new)
+        expect(interactor3).to receive(:new)
+
+        organizer.call
+      end
+
+      it "initializes a double, not a real context, for each interactor" do
+        mock_organizer(organizer)
+
+        expect(interactor1.new.context).to_not be_a(Context)
+        expect(interactor2.new.context).to_not be_a(Context)
+        expect(interactor3.new.context).to_not be_a(Context)
+
+        organizer.call
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,5 +4,6 @@ if ENV["CODECLIMATE_REPO_TOKEN"]
 end
 
 require "interactor"
+require "interactor/test_helpers"
 
 Dir[File.expand_path("../support/*.rb", __FILE__)].each { |f| require f }


### PR DESCRIPTION
Adds a new module called `TestHelpers` (that could be expanded quite a bit) and a method called `mock_organizer` that simplifies the process of stubbing the Interactors in an Organizer with RSpec.

A typical Organizer spec for me looks something like this:

```ruby
RSpec.describe UpdatePasswordOrganizer do
  subject { described_class }

  let(:find_user_by_reset_token) { double("find_user_by_reset_token") }
  let(:check_token_expiration)   { double("check_token_expiration") }
  let(:update_password)          { double("update_password") }

  before(:example) do
    allow(FindUserByResetToken).to receive(:new).
      and_return(find_user_by_reset_token)
    allow(find_user_by_reset_token).to receive(:run!)
    allow(find_user_by_reset_token).to receive(:run)
    allow(find_user_by_reset_token).to receive(:context)

    allow(CheckTokenExpiration).to receive(:new).
      and_return(check_token_expiration)
    allow(check_token_expiration).to receive(:run!)
    allow(check_token_expiration).to receive(:run)
    allow(check_token_expiration).to receive(:context)

    allow(UpdatePassword).to receive(:new).
      and_return(update_password)
    allow(update_password).to receive(:run!)
    allow(update_password).to receive(:run)
    allow(update_password).to receive(:context)
  end

  describe ".call" do
    it "calls the FindUserByResetToken interactor" do
      expect(find_user_by_reset_token).to receive(:run!)
      subject.call
    end

    it "calls the CheckTokenExpiration interactor" do
      expect(check_token_expiration).to receive(:run!)
      subject.call
    end

    it "calls the UpdatePassword interactor" do
      expect(update_password).to receive(:run!)
      subject.call
    end
  end
end
```
This helper cuts it down to something like this --
```ruby
RSpec.describe UpdatePasswordOrganizer do
  include Interactor::TestHelpers

  subject { described_class }

  before(:example) do
    mock_organizer(described_class)
  end

  describe ".call" do
    it "calls the FindUserByResetToken interactor" do
      expect(FindUserByResetToken).to receive(:call!)
      subject.call
    end

    it "calls the CheckTokenExpiration interactor" do
      expect(CheckTokenExpiration).to receive(:call!)
      subject.call
    end

    it "calls the UpdatePassword interactor" do
      expect(UpdatePassword).to receive(:call!)
      subject.call
    end
  end
end
```
Would this be of interest? I'm very open to iterating and welcome any suggestions/comments/concerns! 

I think it would also be cool to have a `mock_interactor` helper that stubs a single Interactor. It wouldn't replace quite as much code but it would be consistent. Happy to include that if the general idea is a keeper.

Also.
![giphy](https://cloud.githubusercontent.com/assets/5838826/12213097/85cea550-b640-11e5-9b57-75fb8c94035b.gif)


