### PR TITLE
 Adds Interactor path transition switch

### DIFF
--- a/lib/interactor.rb
+++ b/lib/interactor.rb
@@ -2,6 +2,7 @@ require "interactor/context"
 require "interactor/error"
 require "interactor/hooks"
 require "interactor/organizer"
+require "interactor/switcher"
 
 # Public: Interactor methods. Because Interactor is a module, custom Interactor
 # classes should include Interactor rather than inherit from it.

--- a/lib/interactor/switcher.rb
+++ b/lib/interactor/switcher.rb
@@ -1,0 +1,130 @@
+module Interactor
+  # Public: Interactor::Switcher methods. Because Interactor::Switcher is a
+  # module, custom Interactor::Switcher classes should include
+  # Interactor::Switcher rather than inherit from it.
+  #
+  # Examples
+  #
+  #   class MySwitcher
+  #     include Interactor::Switcher
+  #
+  #     switch case_1: InteractorOne, case_2: InteractorTwo
+  #   end
+  module Switcher
+    # Internal: Install Interactor::Switcher's behavior in the given class.
+    def self.included(base)
+      base.class_eval do
+        include Interactor
+
+        extend ClassMethods
+        include InstanceMethods
+      end
+    end
+
+    # Internal: Interactor::Switcher class methods.
+    module ClassMethods
+      # Public: Declare Interactors to be invoked as part of the
+      # Interactor::Switcher's invocation. These interactors are invoked based
+      # on the specfied switcher_condition attribute of context.
+      # 
+      # If switcher_condition attribute is not specified, the first argument
+      # of the specified cases will be executed
+      #
+      # interactors
+      # - Zero or more (or an Array of) Interactor classes.
+      # - Only one Array (flat or nested) of Interactor classes
+      # - Only one Hash where:
+      #   - Key defines the case
+      #   - Value single or an Array of Interactor classes.
+      #
+      # Examples:
+      #
+      #   class MyFirstSwitcher
+      #     include Interactor::Switcher
+      #     
+      #     # Providing two cases as Interactor arguments
+      #     switch InteractorOne, InteractorTwo
+      #   end
+      #
+      #   class MyFirstSwitcher
+      #     include Interactor::Switcher
+      #
+      #     # Providing one case as an Array of Interactor arguments
+      #     switch [InteractorOne, InteractorTwo]
+      #   end
+      #
+      #   class MySecondSwitcher
+      #     include Interactor::Switcher
+      #
+      #     # Providing three cases as Arrays of Interactor arguments
+      #     switch [InteractorThree, InteractorFour],
+      #         [InteractorOne, InteractorTwo],
+      #         [InteractorOne]
+      #   end
+      #
+      #   class MySecondSwitcher
+      #     include Interactor::Switcher
+      #
+      #     # Providing three cases as a Hash of Interactor arguments
+      #     switch { 
+      #        path_1: [InteractorThree, InteractorFour],
+      #        path_2: InteractorOne,
+      #        path_3: [InteractorOne]
+      #     }
+      #   end
+      #
+      # Returns nothing.
+      def switch(*interactors)
+        @cases = interactors.first.is_a?(Hash) ? interactors.first : interactors
+      end
+
+      # Internal: An Array or Hash of declared paths to be invoked.
+      #
+      # Examples
+      #
+      #   class MySwitcher
+      #     include Interactor::Switcher
+      #
+      #     switch [InteractorOne, InteractorTwo]
+      #   end
+      #
+      #   MySwitcher.cases
+      #   switch { 
+      #         path_1: [InteractorThree, InteractorFour],
+      #         path_2: [InteractorOne, InteractorTwo],
+      #         path_3: InteractorOne
+      #    }
+      #
+      # Returns an Array or Hash of Interactor classes or an empty Array.
+      def cases
+        @cases ||= []
+      end
+
+    end
+
+    # Internal: Interactor::Switcher instance methods.
+    module InstanceMethods
+      # Internal: Invoke the organized Interactors. An Interactor::Switcher is
+      # expected not to define its own "#call" method in favor of this default
+      # implementation.
+      #
+      # Returns nothing.
+      def call
+        cases = self.class.cases
+
+        unless cases.empty?
+          body = cases[context.switcher_condition]\
+            unless context.switcher_condition.nil?
+          body ||= cases.is_a?(Hash) ? cases.values.first : cases.first
+
+          if body.is_a? Array
+            body.each { |interactor| interactor.call! context }
+          else
+            body.call! context
+          end
+        end
+      end
+
+    end
+  end
+end

--- a/spec/interactor/switcher_spec.rb
+++ b/spec/interactor/switcher_spec.rb
@@ -1,0 +1,139 @@
+module Interactor
+  describe Switcher do
+    include_examples :lint
+
+    let(:switcher) { Class.new.send(:include, Switcher) }
+
+    describe ".switch" do
+      let(:interactor2) { double(:interactor2) }
+      let(:interactor3) { double(:interactor3) }
+
+      it "sets interactors given class arguments as seperate cases" do
+        expect {
+          switcher.switch(interactor2, interactor3)
+        }.to change {
+          switcher.cases
+        }.from([]).to([interactor2, interactor3])
+      end
+
+      it "sets interactors given an array of classes as one case" do
+        expect {
+          switcher.switch([interactor2, interactor3])
+        }.to change {
+          switcher.cases
+        }.from([]).to([[interactor2, interactor3]])
+      end
+
+      it "sets interactors given a hash of class arguments" do
+        expect {
+          switcher.switch({ path1: interactor2, path2: interactor3 })
+        }.to change {
+          switcher.cases
+        }.from([]).to({ path1: interactor2, path2: interactor3 })
+      end
+
+      it "sets interactors given a hash that accepts values of arrays of class arguments" do
+        expect {
+          switcher.switch({ path1: [interactor2, interactor3], path2: interactor3 })
+        }.to change {
+          switcher.cases
+        }.from([]).to({ path1: [interactor2, interactor3], path2: interactor3 })
+      end
+
+    end
+
+    describe ".cases" do
+      it "is empty by default" do
+        expect(switcher.cases).to eq([])
+      end
+    end
+
+    describe "#call" do
+      let(:instance) { switcher.new }
+      let(:context) { Interactor::Context.new }
+      let(:interactor2) { double(:interactor2) }
+      let(:interactor3) { double(:interactor3) }
+      let(:interactor4) { double(:interactor4) }
+
+      before do
+        allow(instance).to receive(:context) { context }
+      end
+
+      it "calls the first case by default for flat arrays if switcher_condition is not specified" do
+        allow(switcher).to receive(:cases) {
+          [interactor2, interactor3, interactor4]
+        }
+
+        expect(interactor2).to receive(:call!).once.with(context)
+        expect(interactor3).to_not receive(:call!).with(context)
+        expect(interactor4).to_not receive(:call!).with(context)
+
+        instance.call
+      end
+
+      it "calls the first case by default for nested arrays if switcher_condition is not specified" do
+        allow(switcher).to receive(:cases) {
+          [[interactor2, interactor3], interactor4]
+        }
+
+        expect(interactor2).to receive(:call!).once.with(context).ordered
+        expect(interactor3).to receive(:call!).once.with(context).ordered
+        expect(interactor4).to_not receive(:call!).with(context)
+
+        instance.call
+      end
+
+
+      it "calls the first case by default for hashes if switcher_condition is not specified" do
+        allow(switcher).to receive(:cases) {
+          { case_1: [interactor2, interactor3], case_2: interactor4 }
+        }
+
+        expect(interactor2).to receive(:call!).once.with(context).ordered
+        expect(interactor3).to receive(:call!).once.with(context).ordered
+        expect(interactor4).to_not receive(:call!).with(context)
+
+        instance.call
+      end
+    end
+
+    describe "#call" do
+      let(:instance) { switcher.new }
+      let(:interactor2) { double(:interactor2) }
+      let(:interactor3) { double(:interactor3) }
+      let(:interactor4) { double(:interactor4) }
+
+      it "calls the corresponding switcher_condition from cases of type Array" do
+        context = Interactor::Context.new switcher_condition: 1
+
+        allow(instance).to receive(:context) { context }
+        allow(switcher).to receive(:cases) {
+          [[interactor2, interactor3], interactor4]
+        }
+
+        expect(interactor2).to_not receive(:call!).with(context)
+        expect(interactor3).to_not receive(:call!).with(context)
+        expect(interactor4).to receive(:call!).once.with(context)
+
+        instance.call
+      end
+
+      it "calls the corresponding switcher_condition from cases of type Hash" do
+        context = Interactor::Context.new switcher_condition: :path_1
+
+        allow(instance).to receive(:context) { context }
+        allow(switcher).to receive(:cases) {
+          { path_1: [interactor2, interactor3], path_2: interactor4 }
+        }
+
+        expect(interactor2).to receive(:call!).once.with(context).ordered
+        expect(interactor3).to receive(:call!).once.with(context).ordered
+        expect(interactor4).to_not receive(:call!).with(context)
+
+        instance.call
+      end
+
+    end
+
+  end
+end


### PR DESCRIPTION
Introducing Switcher: a new type of Interactors. Switcher aims to provide a path transition switch mechanism. Each path can be an Interactor or an Organizer that defines multiple scenarios of application's business logic.
# Flow

For example, consider the following diagram:

![diagram 001](https://cloud.githubusercontent.com/assets/4674035/16398245/fff71d4a-3cd1-11e6-802b-173b0da41abe.jpeg)

The **S** class in the previous diagram can be defined as:

```
class S
  include Interactor::Switcher

  # Switch
  # First path: [B, E]
  # Second path: C

  switch [B, E], C
end
```

Switcher's behaviour is controlled by **switcher_condition** attribute that can be provided through the library's regular **context** object. Hence, if _context_.**switcher_condition** equals 1, then the second path, that includes **C**, will be executed.
## .switch class Method

The **switch** class method accepts arguments in one of the following flavours:
- **_List of Interactor class arguments:_** 
  
  ```
   #1st path: A
   #2nd path: B
   #3rd path: C
  
   switch A, B, C
  ```
  - Where each argument is considered as a separate path.
  - A path can be selected by its index.
- **_An array of arguments:_**
  
  ```
   #path: A, B, C
  
   switch [A, B, C]
  ```
  - Defines a single path. 
  - A path can be selected by its index.
- **_A hash of arguments:_**
  
  ```
   #1st path: A, B
   #2nd path: C
  
   switch key_1: [A, B], key_2: C
  ```
  - Where each key refers to a separate path. 
  - A path can be selected by its key.
### General Note:
- A path is an Array input.
- If **switcher_condition** is not available, the switcher executes the first path by default.
# TODO
- Fix comments and tests' description typos.
- Add the ability to change the control argument name per switcher. **switcher_condition**
- Add documentations.
