### PR TITLE
add .parameters and .parameters! methods for input parameters expectations on call

### DIFF
--- a/spec/support/lint.rb
+++ b/spec/support/lint.rb
@@ -61,6 +61,53 @@ shared_examples :lint do
     end
   end
 
+  describe ".parameters" do
+    let(:context) { double(:context, foo: "foo", bar: "bar") }
+    let(:instance) { interactor.new }
+
+    it "defines instance parameter methods" do
+      expect(Interactor::Context).to receive(:build) { context }
+
+      interactor.parameters(:foo, :bar)
+
+      expect(instance.private_methods).to include(:foo, :bar)
+      expect(instance.send(:foo)).to eq "foo"
+      expect(instance.send(:bar)).to eq "bar"
+    end
+  end
+
+  describe ".parameters!" do
+    it "defines instance parameter methods" do
+      expect(interactor).to receive(:parameters).with(:foo, :bar).once
+
+      interactor.parameters!(:foo, :bar)
+    end
+
+    context "with missing parameter" do
+      let(:context) { double foo: "foo", bar: nil, called!: double }
+
+      it "fails the context" do
+        expect(Interactor::Context).to receive(:build) { context }
+        expect(context).to receive(:fail!)
+
+        interactor.parameters!(:foo, :bar)
+        interactor.call
+      end
+    end
+
+    context "with all required parameters specified" do
+      let(:context) { double foo: "foo", bar: "bar", called!: double }
+
+      it "does not fail the context" do
+        expect(Interactor::Context).to receive(:build) { context }
+        expect(context).not_to receive(:fail!)
+
+        interactor.parameters!(:foo, :bar)
+        interactor.call
+      end
+    end
+  end
+
   describe "#run" do
     let(:instance) { interactor.new }
 


### PR DESCRIPTION
Сurrently, you can never be sure, what parameters will be specified in the `context` on call. I need to grep for `call` invocations across the project or look through the entire interactor carefully for `context.foo` things to understand what are the input variables.
We use interactors quite often and now have an internal convention to declare parameters like this:

``` ruby
class Out
  include Interactor

  delegate :message, to: :context

  def call
    puts message
  end
end

Out.call(message: "Hi!")
Hi!
=> #<Interactor::Context message="Hi!">
```

thus, it is very easy to see what do we need to specify to make this interactor working without deep understanding of its contents.
I think that this is a good practice, and perhaps there should be a method to do this.

This PR introduces two new methods:
`.parameters` - simply defines specified delegators to the `context`. So, previous example would look like this:

``` ruby
class Out
  include Interactor

  parameters :message

  def call
    puts message
  end
end

Out.call(message: "Hi!")
Hi!
=> #<Interactor::Context message="Hi!">
```

`.parameters!` - does essentially the same, but adds a before hook that will fail the context if any of specified params is missing.

``` ruby
class Baz
  include Interactor

  parameters! :foo, :bar

  def call
    puts "#{foo} #{bar}"
  end
end

Baz.call(foo: "hello", bar: "world")
hello world
=> #<Interactor::Context foo="hello", bar="world">
Baz.call!(foo: "hello")
=> #<Interactor::Failure: #<Interactor::Context foo="hello">>
```

I see that there are some related issues (https://github.com/collectiveidea/interactor/issues/92, https://github.com/collectiveidea/interactor/issues/67, https://github.com/collectiveidea/interactor/issues/109) and even a PR (https://github.com/collectiveidea/interactor/pull/82) which evolved to a separate gem (https://github.com/jonstokes/troupe).
To be honest, I was lazy enough not to read all of those threads from beginning to end :smile:. So, maybe this solution has been already discussed and rejected for some reasons.

I'm not sure about the name of this methods, but it looks as a very simple solution that will stick well with lightness if interactors.
