### PR TITLE
Add Interactor Requirements

### DIFF
--- a/lib/interactor.rb
+++ b/lib/interactor.rb
@@ -2,6 +2,7 @@ require "interactor/context"
 require "interactor/error"
 require "interactor/hooks"
 require "interactor/organizer"
+require "interactor/requirements"
 
 # Public: Interactor methods. Because Interactor is a module, custom Interactor
 # classes should include Interactor rather than inherit from it.
@@ -21,6 +22,7 @@ module Interactor
     base.class_eval do
       extend ClassMethods
       include Hooks
+      include Requirements
 
       # Public: Gets the Interactor::Context of the Interactor instance.
       attr_reader :context

--- a/lib/interactor/error.rb
+++ b/lib/interactor/error.rb
@@ -28,4 +28,11 @@ module Interactor
       super
     end
   end
+
+  # Internal: Error gets raised if context params are required
+  # but are either not specified, are nil, or are not the specified type.
+  class RequirementsNotMet < StandardError
+
+  end
+
 end

--- a/lib/interactor/requirements.rb
+++ b/lib/interactor/requirements.rb
@@ -1,0 +1,43 @@
+module Interactor
+
+  module Requirements
+
+    def self.included(base)
+      base.extend(ClassMethods)
+    end
+
+    module ClassMethods
+      def context_requires(*params)
+        if params.empty?
+          raise "Must specify at least one param"
+        end
+        typed_params = nil
+        if params.last.is_a? Hash
+          typed_params = params.pop
+        end
+
+        # We need to check the typed_params for existence as well
+        params = params + typed_params.keys unless typed_params.nil?
+
+        before do
+          params.each do |param_name|
+            if !context.respond_to?(param_name)
+              raise RequirementsNotMet, "Context requires #{param_name}, but it wasn't specified"
+            elsif context.send(param_name).nil?
+              raise RequirementsNotMet, "Context requires #{param_name}, but it was nil"
+            end
+          end
+          next if typed_params.nil?
+          typed_params.each do |param_name, param_type|
+            raise RequirementsNotMet, "The type specified for #{param_name} must be a Class (got #{param_type.class})" if param_type.class != Class
+            given_value = context.send(param_name)
+            if !given_value.is_a? param_type
+              raise RequirementsNotMet, "Context requires #{param_name} to be a #{param_type}, but it was a #{given_value.class}."
+            end
+          end
+        end
+      end
+    end
+
+  end
+end

--- a/spec/interactor/requirements_spec.rb
+++ b/spec/interactor/requirements_spec.rb
@@ -1,0 +1,50 @@
+module Interactor
+  describe Interactor do
+    include_examples :lint
+
+    class InteractorWithSimpleRequirements
+      include Interactor
+      context_requires :some_object
+    end
+
+    class InteractorWithTypedRequirements
+      include Interactor
+      context_requires some_string: String, some_hash: Hash
+    end
+
+    class InteractorWithMixedRequirements
+      include Interactor
+      context_requires :another_object, some_string: String
+    end
+
+    describe ".context_requires" do
+      describe "with a simple requirement" do
+        it "passes if the requirement exists" do
+          expect{InteractorWithSimpleRequirements.call(some_object: 123)}.to_not raise_error
+        end
+        it "raises an error if it's missing a requirement" do
+          expect{InteractorWithSimpleRequirements.call}.to raise_error(Interactor::RequirementsNotMet)
+        end
+        it "raises an error if it's a requirement is nil" do
+          expect{InteractorWithSimpleRequirements.call(some_object: nil)}.to raise_error(Interactor::RequirementsNotMet)
+        end
+      end
+      describe "with typed requirements" do
+        it "raises an error if it's missing a requirement" do
+          expect{InteractorWithTypedRequirements.call(some_string: nil)}.to raise_error(Interactor::RequirementsNotMet)        
+        end
+        it "raises an error if a requirement has the wrong type" do
+          expect{InteractorWithTypedRequirements.call(some_string: 123)}.to raise_error(Interactor::RequirementsNotMet)        
+        end
+      end
+      describe "with mixed requirements" do
+        it "raises an error if it's missing a requirement" do
+          expect{InteractorWithMixedRequirements.call(some_string: "abc")}.to raise_error(Interactor::RequirementsNotMet)        
+        end
+        it "raises an error if a requirement has the wrong type" do
+          expect{InteractorWithMixedRequirements.call(some_string: 123)}.to raise_error(Interactor::RequirementsNotMet)        
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds a _very, very_ simple contract DSL on top of Interactors.  I know that #112 and #82 both exist, **however** I believe that neither of them have gained traction/have been merged because they are either too complex, try to do too much, or break backwards compatibility.

This PR simply adds the class method `context_requires`, which can be used like so:

``` ruby
class SendEmail
  include Interactor
  context_requires :email
  # or like this:
  # context_requires :email, :user_id
  # or like this, with strictly typed params
  # context_requires :email, user_id: String
  # context_requires email: String, user_id: Integer, some_options: Hash
  def call
    UserMailer.welcome_email(context.email).deliver
  end  
end
```

Since this is a developer tool (not for users to see), this raises a new exception, `Interactor::RequirementsNotMet` if eg. `email` is `nil` or not specified when the interactor is called with one of the following messages:

``` ruby
SendEmail.call
# => InteractorRequirements::RequirementsNotMet: Context requires email, but it wasn't specified
SendEmail.call(email: nil)
# => InteractorRequirements::RequirementsNotMet: Context requires email, but it was nil
```

or with type requirements:

``` ruby
SendEmail.call(email: "some@example.com", user_id: 1.5)
# => InteractorRequirements::RequirementsNotMet: Context requires account_id to be a String, but it was a Float.
```

Credit to @Mingan for the code that this is based on.

Addresses #92 , #109
