### PR TITLE
add rubocop and drop support for Rubies < 2.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,51 @@
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
+# Allow some style changes in specs
+Metrics/ModuleLength:
+  Exclude:
+    - spec/**/*
+Metrics/BlockLength:
+  Exclude:
+    - spec/**/*
+Style/BlockDelimiters:
+  Exclude:
+    - spec/**/*
+Style/RescueModifier:
+  Exclude:
+    - spec/**/*
+Metrics/MethodLength:
+  Exclude:
+    - spec/interactor/hooks_spec.rb
+Style/IndentArray:
+  Exclude:
+    - spec/integration_spec.rb
+    - spec/interactor/hooks_spec.rb
+
+# Allow nice tree-like comments in specs
+Style/AsciiComments:
+  Exclude:
+    - spec/integration_spec.rb
+
+# Here inconsistent indentation helps to understand
+# tree nature of callbacks.
+Style/AlignArray:
+  Exclude:
+    - spec/integration_spec.rb
+
+# Rubocop suggests using $INPUT_RECORD_SEPARATOR
+# variable from stdlib 'English' module over $/.
+# This module appeared in Ruby 2.0, so we could use it
+# only if we drop 1.9.3 support
+Style/SpecialGlobalVars:
+  Exclude:
+    - interactor.gemspec
+
+# This could be removed if throws are used instead of
+# raising Failure in #fail!
+Lint/HandleExceptions:
+  Exclude:
+    - lib/interactor.rb

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -46,4 +46,4 @@ Style/EmptyMethod:
   Enabled: false
 
 AllCops:
-  TargetRubyVersion: 2.1
+  TargetRubyVersion: 2.0

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -42,5 +42,8 @@ Lint/HandleExceptions:
   Exclude:
     - lib/interactor.rb
 
+Style/EmptyMethod:
+  Enabled: false
+
 AllCops:
   TargetRubyVersion: 2.1

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -36,16 +36,11 @@ Style/AlignArray:
   Exclude:
     - spec/integration_spec.rb
 
-# Rubocop suggests using $INPUT_RECORD_SEPARATOR
-# variable from stdlib 'English' module over $/.
-# This module appeared in Ruby 2.0, so we could use it
-# only if we drop 1.9.3 support
-Style/SpecialGlobalVars:
-  Exclude:
-    - interactor.gemspec
-
 # This could be removed if throws are used instead of
 # raising Failure in #fail!
 Lint/HandleExceptions:
   Exclude:
     - lib/interactor.rb
+
+AllCops:
+  TargetRubyVersion: 2.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,4 +27,4 @@ rvm:
   - "2.3.3"
   - "2.4.0"
   - ruby-head
-script: bundle exec rspec
+script: bundle exec rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,12 +15,14 @@ language: ruby
 matrix:
   allow_failures:
     - rvm: ruby-head
+    - rvm: "2.0"
 notifications:
   webhooks:
     on_start: always
     urls:
       - http://buildlight.collectiveidea.com/
 rvm:
+  - "2.0"
   - "2.1"
   - "2.2"
   - "2.3.3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,6 @@ notifications:
     urls:
       - http://buildlight.collectiveidea.com/
 rvm:
-  - 1.9.3
-  - "2.0"
   - "2.1"
   - "2.2"
   - "2.3.3"

--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,5 @@ gemspec
 group :test do
   gem "codeclimate-test-reporter", require: false
   gem "rspec", "~> 3.2"
+  gem "rubocop", "~> 0.47.1"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,8 @@
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
+require "rubocop/rake_task"
 
 RSpec::Core::RakeTask.new(:spec)
+RuboCop::RakeTask.new(:rubocop)
 
-task default: :spec
+task default: [:spec, :rubocop]

--- a/interactor.gemspec
+++ b/interactor.gemspec
@@ -6,7 +6,8 @@ Gem::Specification.new do |spec|
 
   spec.author      = "Collective Idea"
   spec.email       = "info@collectiveidea.com"
-  spec.description = "Interactor provides a common interface for performing complex user interactions."
+  spec.description = "Interactor provides a common interface for performing " \
+                     "complex user interactions."
   spec.summary     = "Simple interactor implementation"
   spec.homepage    = "https://github.com/collectiveidea/interactor"
   spec.license     = "MIT"
@@ -16,4 +17,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.3"
+  spec.add_development_dependency "rubocop", "~> 0.47.1"
 end

--- a/interactor.gemspec
+++ b/interactor.gemspec
@@ -1,4 +1,5 @@
 # encoding: utf-8
+require "English"
 
 Gem::Specification.new do |spec|
   spec.name    = "interactor"
@@ -12,8 +13,10 @@ Gem::Specification.new do |spec|
   spec.homepage    = "https://github.com/collectiveidea/interactor"
   spec.license     = "MIT"
 
-  spec.files      = `git ls-files`.split($/)
+  spec.files      = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
   spec.test_files = spec.files.grep(/^spec/)
+
+  spec.required_ruby_version = ">= 2.1"
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.3"

--- a/interactor.gemspec
+++ b/interactor.gemspec
@@ -16,7 +16,8 @@ Gem::Specification.new do |spec|
   spec.files      = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
   spec.test_files = spec.files.grep(/^spec/)
 
+  spec.required_ruby_version = ">= 2.0"
+
   spec.add_development_dependency "bundler", "~> 1.9"
   spec.add_development_dependency "rake", "~> 10.4"
-  spec.add_development_dependency "rubocop", "~> 0.47.1"
 end

--- a/lib/interactor.rb
+++ b/lib/interactor.rb
@@ -153,14 +153,12 @@ module Interactor
   # each interactor class.
   #
   # Returns nothing.
-  def call
-  end
+  def call; end
 
   # Public: Reverse prior invocation of an Interactor instance. Any interactor
   # class that requires undoing upon downstream failure is expected to overwrite
   # the "rollback" instance method.
   #
   # Returns nothing.
-  def rollback
-  end
+  def rollback; end
 end

--- a/lib/interactor.rb
+++ b/lib/interactor.rb
@@ -153,12 +153,14 @@ module Interactor
   # each interactor class.
   #
   # Returns nothing.
-  def call; end
+  def call
+  end
 
   # Public: Reverse prior invocation of an Interactor instance. Any interactor
   # class that requires undoing upon downstream failure is expected to overwrite
   # the "rollback" instance method.
   #
   # Returns nothing.
-  def rollback; end
+  def rollback
+  end
 end

--- a/lib/interactor/context.rb
+++ b/lib/interactor/context.rb
@@ -53,7 +53,7 @@ module Interactor
     #
     # Returns the Interactor::Context.
     def self.build(context = {})
-      self === context ? context : new(context)
+      context.is_a?(Context) ? context : new(context)
     end
 
     # Public: Whether the Interactor::Context is successful. By default, a new

--- a/lib/interactor/hooks.rb
+++ b/lib/interactor/hooks.rb
@@ -219,9 +219,9 @@ module Interactor
     #
     # Returns nothing.
     def run_around_hooks(&block)
-      self.class.around_hooks.reverse.inject(block) { |chain, hook|
+      self.class.around_hooks.reverse.inject(block) do |chain, hook|
         proc { run_hook(hook, chain) }
-      }.call
+      end.call
     end
 
     # Internal: Run before hooks.

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -25,7 +25,8 @@ describe "Integration" do
   #  └─ interactor5
 
   let(:organizer) {
-    build_organizer(organize: [organizer2, interactor3, organizer4, interactor5]) do
+    interactors = [organizer2, interactor3, organizer4, interactor5]
+    build_organizer(organize: interactors) do
       around do |interactor|
         context.steps << :around_before
         interactor.call
@@ -315,7 +316,8 @@ describe "Integration" do
 
   context "when an around hook fails early" do
     let(:organizer) {
-      build_organizer(organize: [organizer2, interactor3, organizer4, interactor5]) do
+      interactors = [organizer2, interactor3, organizer4, interactor5]
+      build_organizer(organize: interactors) do
         around do |interactor|
           context.fail!
           context.steps << :around_before
@@ -345,12 +347,10 @@ describe "Integration" do
 
   context "when an around hook errors early" do
     let(:organizer) {
-      build_organizer(organize: [organizer2, interactor3, organizer4, interactor5]) do
-        around do |interactor|
+      interactors = [organizer2, interactor3, organizer4, interactor5]
+      build_organizer(organize: interactors) do
+        around do |_interactor|
           raise "foo"
-          context.steps << :around_before
-          interactor.call
-          context.steps << :around_after
         end
 
         before do
@@ -381,7 +381,8 @@ describe "Integration" do
 
   context "when a before hook fails" do
     let(:organizer) {
-      build_organizer(organize: [organizer2, interactor3, organizer4, interactor5]) do
+      interactors = [organizer2, interactor3, organizer4, interactor5]
+      build_organizer(organize: interactors) do
         around do |interactor|
           context.steps << :around_before
           interactor.call
@@ -412,7 +413,8 @@ describe "Integration" do
 
   context "when a before hook errors" do
     let(:organizer) {
-      build_organizer(organize: [organizer2, interactor3, organizer4, interactor5]) do
+      interactors = [organizer2, interactor3, organizer4, interactor5]
+      build_organizer(organize: interactors) do
         around do |interactor|
           context.steps << :around_before
           interactor.call
@@ -421,7 +423,6 @@ describe "Integration" do
 
         before do
           raise "foo"
-          context.steps << :before
         end
 
         after do
@@ -449,7 +450,8 @@ describe "Integration" do
 
   context "when an after hook fails" do
     let(:organizer) {
-      build_organizer(organize: [organizer2, interactor3, organizer4, interactor5]) do
+      interactors = [organizer2, interactor3, organizer4, interactor5]
+      build_organizer(organize: interactors) do
         around do |interactor|
           context.steps << :around_before
           interactor.call
@@ -500,7 +502,8 @@ describe "Integration" do
 
   context "when an after hook errors" do
     let(:organizer) {
-      build_organizer(organize: [organizer2, interactor3, organizer4, interactor5]) do
+      interactors = [organizer2, interactor3, organizer4, interactor5]
+      build_organizer(organize: interactors) do
         around do |interactor|
           context.steps << :around_before
           interactor.call
@@ -513,7 +516,6 @@ describe "Integration" do
 
         after do
           raise "foo"
-          context.steps << :after
         end
       end
     }
@@ -557,7 +559,8 @@ describe "Integration" do
 
   context "when an around hook fails late" do
     let(:organizer) {
-      build_organizer(organize: [organizer2, interactor3, organizer4, interactor5]) do
+      interactors = [organizer2, interactor3, organizer4, interactor5]
+      build_organizer(organize: interactors) do
         around do |interactor|
           context.steps << :around_before
           interactor.call
@@ -609,12 +612,12 @@ describe "Integration" do
 
   context "when an around hook errors late" do
     let(:organizer) {
-      build_organizer(organize: [organizer2, interactor3, organizer4, interactor5]) do
+      interactors = [organizer2, interactor3, organizer4, interactor5]
+      build_organizer(organize: interactors) do
         around do |interactor|
           context.steps << :around_before
           interactor.call
           raise "foo"
-          context.steps << :around_after
         end
 
         before do
@@ -715,11 +718,8 @@ describe "Integration" do
   context "when a nested around hook errors early" do
     let(:interactor3) {
       build_interactor do
-        around do |interactor|
+        around do |_interactor|
           raise "foo"
-          context.steps << :around_before3
-          interactor.call
-          context.steps << :around_after3
         end
 
         before do
@@ -824,7 +824,6 @@ describe "Integration" do
 
         before do
           raise "foo"
-          context.steps << :before3
         end
 
         after do
@@ -934,7 +933,6 @@ describe "Integration" do
 
         def call
           raise "foo"
-          context.steps << :call3
         end
 
         def rollback
@@ -1033,7 +1031,6 @@ describe "Integration" do
 
         after do
           raise "foo"
-          context.steps << :after3
         end
 
         def call
@@ -1129,7 +1126,6 @@ describe "Integration" do
           context.steps << :around_before3
           interactor.call
           raise "foo"
-          context.steps << :around_after3
         end
 
         before do
@@ -1232,11 +1228,8 @@ describe "Integration" do
   context "when a deeply nested around hook errors early" do
     let(:interactor4b) {
       build_interactor do
-        around do |interactor|
+        around do |_interactor|
           raise "foo"
-          context.steps << :around_before4b
-          interactor.call
-          context.steps << :around_after4b
         end
 
         before do
@@ -1351,7 +1344,6 @@ describe "Integration" do
 
         before do
           raise "foo"
-          context.steps << :before4b
         end
 
         after do
@@ -1471,7 +1463,6 @@ describe "Integration" do
 
         def call
           raise "foo"
-          context.steps << :call4b
         end
 
         def rollback
@@ -1580,7 +1571,6 @@ describe "Integration" do
 
         after do
           raise "foo"
-          context.steps << :after4b
         end
 
         def call
@@ -1686,7 +1676,6 @@ describe "Integration" do
           context.steps << :around_before4b
           interactor.call
           raise "foo"
-          context.steps << :around_after4b
         end
 
         before do

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -2,6 +2,11 @@ describe "Integration" do
   def build_interactor(&block)
     interactor = Class.new.send(:include, Interactor)
     interactor.class_eval(&block) if block
+    interactor.class_eval do
+      def unexpected_error!
+        raise "foo"
+      end
+    end
     interactor
   end
 
@@ -9,6 +14,11 @@ describe "Integration" do
     organizer = Class.new.send(:include, Interactor::Organizer)
     organizer.organize(options[:organize]) if options[:organize]
     organizer.class_eval(&block) if block
+    organizer.class_eval do
+      def unexpected_error!
+        raise "foo"
+      end
+    end
     organizer
   end
 
@@ -349,8 +359,11 @@ describe "Integration" do
     let(:organizer) {
       interactors = [organizer2, interactor3, organizer4, interactor5]
       build_organizer(organize: interactors) do
-        around do |_interactor|
-          raise "foo"
+        around do |interactor|
+          unexpected_error!
+          context.steps << :around_before
+          interactor.call
+          context.steps << :around_after
         end
 
         before do
@@ -422,7 +435,8 @@ describe "Integration" do
         end
 
         before do
-          raise "foo"
+          unexpected_error!
+          context.steps << :before
         end
 
         after do
@@ -515,7 +529,8 @@ describe "Integration" do
         end
 
         after do
-          raise "foo"
+          unexpected_error!
+          context.steps << :after
         end
       end
     }
@@ -617,7 +632,8 @@ describe "Integration" do
         around do |interactor|
           context.steps << :around_before
           interactor.call
-          raise "foo"
+          unexpected_error!
+          context.steps << :around_after
         end
 
         before do
@@ -718,8 +734,11 @@ describe "Integration" do
   context "when a nested around hook errors early" do
     let(:interactor3) {
       build_interactor do
-        around do |_interactor|
-          raise "foo"
+        around do |interactor|
+          unexpected_error!
+          context.steps << :around_before3
+          interactor.call
+          context.steps << :around_after3
         end
 
         before do
@@ -823,7 +842,8 @@ describe "Integration" do
         end
 
         before do
-          raise "foo"
+          unexpected_error!
+          context.steps << :before3
         end
 
         after do
@@ -932,7 +952,8 @@ describe "Integration" do
         end
 
         def call
-          raise "foo"
+          unexpected_error!
+          context.steps << :call3
         end
 
         def rollback
@@ -1030,7 +1051,8 @@ describe "Integration" do
         end
 
         after do
-          raise "foo"
+          unexpected_error!
+          context.steps << :after3
         end
 
         def call
@@ -1125,7 +1147,8 @@ describe "Integration" do
         around do |interactor|
           context.steps << :around_before3
           interactor.call
-          raise "foo"
+          unexpected_error!
+          context.steps << :around_after3
         end
 
         before do
@@ -1228,8 +1251,11 @@ describe "Integration" do
   context "when a deeply nested around hook errors early" do
     let(:interactor4b) {
       build_interactor do
-        around do |_interactor|
-          raise "foo"
+        around do |interactor|
+          unexpected_error!
+          context.steps << :around_before4b
+          interactor.call
+          context.steps << :around_after4b
         end
 
         before do
@@ -1343,7 +1369,8 @@ describe "Integration" do
         end
 
         before do
-          raise "foo"
+          unexpected_error!
+          context.steps << :before4b
         end
 
         after do
@@ -1462,7 +1489,8 @@ describe "Integration" do
         end
 
         def call
-          raise "foo"
+          unexpected_error!
+          context.steps << :call4b
         end
 
         def rollback
@@ -1570,7 +1598,8 @@ describe "Integration" do
         end
 
         after do
-          raise "foo"
+          unexpected_error!
+          context.steps << :after4b
         end
 
         def call
@@ -1675,7 +1704,8 @@ describe "Integration" do
         around do |interactor|
           context.steps << :around_before4b
           interactor.call
-          raise "foo"
+          unexpected_error!
+          context.steps << :around_after4b
         end
 
         before do

--- a/spec/support/lint.rb
+++ b/spec/support/lint.rb
@@ -43,7 +43,9 @@ shared_examples :lint do
     let(:context) { double(:context) }
 
     it "initializes a context" do
-      expect(Interactor::Context).to receive(:build).once.with(foo: "bar") { context }
+      expect(
+        Interactor::Context
+      ).to receive(:build).once.with(foo: "bar") { context }
 
       instance = interactor.new(foo: "bar")
 

--- a/spec/support/lint.rb
+++ b/spec/support/lint.rb
@@ -43,9 +43,8 @@ shared_examples :lint do
     let(:context) { double(:context) }
 
     it "initializes a context" do
-      expect(
-        Interactor::Context
-      ).to receive(:build).once.with(foo: "bar") { context }
+      expect(Interactor::Context).to receive(:build)
+        .once.with(foo: "bar") { context }
 
       instance = interactor.new(foo: "bar")
 


### PR DESCRIPTION
This PR consists of two commits. First one introduces following changes:

- Adds `rubocop` as a dev dependency (use conservative version locking as official manual [advises](http://rubocop.readthedocs.io/en/latest/installation/);
- Adds `.rubocop.yml` config;
- Fixes some style issues;
- Changes default `rake` task;
- Updates `travis.yml` to run `rake` instead of `rspec`

When first commit failed Travis checks I realized that fresh Rubocop requires only Ruby >= 2.0. Keeping in mind that [there is a plan to drop support for Rubies < 2.1](https://github.com/collectiveidea/interactor/projects/1) in Interactor 4.0, I've decided to update this PR accordingly.

So the second commit does following: 
- removes Rubies 1.9.3, 2.0 from Travis config;
- sets Rubocop target Ruby version to 2.1;
- add `required_ruby_version = ">= 2.1"` in gemspec.