### PR TITLE
Replace raise with throw to handle context failure

### DIFF
--- a/lib/interactor/context.rb
+++ b/lib/interactor/context.rb
@@ -123,6 +123,10 @@ module Interactor
     def fail!(context = {})
       context.each { |key, value| modifiable[key.to_sym] = value }
       @failure = true
+      signal_early_return!
+    end
+
+    def signal_early_return!
       throw :early_return
     end
 

--- a/lib/interactor/context.rb
+++ b/lib/interactor/context.rb
@@ -123,7 +123,7 @@ module Interactor
     def fail!(context = {})
       context.each { |key, value| modifiable[key.to_sym] = value }
       @failure = true
-      raise Failure, self
+      throw :early_return
     end
 
     # Internal: Track that an Interactor has been called. The "called!" method

--- a/lib/interactor/organizer.rb
+++ b/lib/interactor/organizer.rb
@@ -8,7 +8,7 @@ module Interactor
   #   class MyOrganizer
   #     include Interactor::Organizer
   #
-  #     organizer InteractorOne, InteractorTwo
+  #     organize InteractorOne, InteractorTwo
   #   end
   module Organizer
     # Internal: Install Interactor::Organizer's behavior in the given class.
@@ -77,7 +77,8 @@ module Interactor
       # Returns nothing.
       def call
         self.class.organized.each do |interactor|
-          interactor.call!(context)
+          throw(:early_return) if context.failure?
+          interactor.call(context)
         end
       end
     end

--- a/lib/interactor/organizer.rb
+++ b/lib/interactor/organizer.rb
@@ -77,7 +77,7 @@ module Interactor
       # Returns nothing.
       def call
         self.class.organized.each do |interactor|
-          throw(:early_return) if context.failure?
+          context.signal_early_return! if context.failure?
           interactor.call(context)
         end
       end

--- a/spec/interactor/context_spec.rb
+++ b/spec/interactor/context_spec.rb
@@ -109,18 +109,10 @@ module Interactor
         }.from("bar").to("baz")
       end
 
-      it "raises failure" do
+      it "throws :early_return" do
         expect {
           context.fail!
-        }.to raise_error(Failure)
-      end
-
-      it "makes the context available from the failure" do
-        begin
-          context.fail!
-        rescue Failure => error
-          expect(error.context).to eq(context)
-        end
+        }.to throw_symbol(:early_return)
       end
     end
 

--- a/spec/interactor/organizer_spec.rb
+++ b/spec/interactor/organizer_spec.rb
@@ -65,11 +65,12 @@ module Interactor
         instance.call
       end
 
-      it "throws :early_return on failure of one of organizers" do
+      it "signals about early_return on failure of one of organizers" do
         allow(context).to receive(:failure?).and_return(false, true)
+        expect(context).to receive(:signal_early_return!).and_throw(:foo)
         expect {
           instance.call
-        }.to throw_symbol(:early_return)
+        }.to throw_symbol
       end
     end
   end

--- a/spec/interactor/organizer_spec.rb
+++ b/spec/interactor/organizer_spec.rb
@@ -43,24 +43,33 @@ module Interactor
 
     describe "#call" do
       let(:instance) { organizer.new }
-      let(:context) { double(:context) }
+      let(:context) { double(:context, failure?: false) }
       let(:interactor2) { double(:interactor2) }
       let(:interactor3) { double(:interactor3) }
       let(:interactor4) { double(:interactor4) }
+      let(:organized_interactors) { [interactor2, interactor3, interactor4] }
 
       before do
         allow(instance).to receive(:context) { context }
-        allow(organizer).to receive(:organized) {
-          [interactor2, interactor3, interactor4]
-        }
+        allow(organizer).to receive(:organized) { organized_interactors }
+        organized_interactors.each do |organized_interactor|
+          allow(organized_interactor).to receive(:call)
+        end
       end
 
       it "calls each interactor in order with the context" do
-        expect(interactor2).to receive(:call!).once.with(context).ordered
-        expect(interactor3).to receive(:call!).once.with(context).ordered
-        expect(interactor4).to receive(:call!).once.with(context).ordered
+        expect(interactor2).to receive(:call).once.with(context).ordered
+        expect(interactor3).to receive(:call).once.with(context).ordered
+        expect(interactor4).to receive(:call).once.with(context).ordered
 
         instance.call
+      end
+
+      it "throws :early_return on failure of one of organizers" do
+        allow(context).to receive(:failure?).and_return(false, true)
+        expect {
+          instance.call
+        }.to throw_symbol(:early_return)
       end
     end
   end


### PR DESCRIPTION
Implements #126.

### Thrown symbol name

I've decided to pick `:early_return` because we're going to support early success as well as failure. 
At the earlier stage of implementing this I introduced an additional argument to throw:

```ruby
throw :early_return, RunFailure.new(self)
```

But then I realized it's redundant: context itself knows is it successful or failed.

### Aborting organized interactors chain execution on failure

Earlier we used `#call!` which raised an error to ensure this; now it's not true. To tackle this problem I've decided to check if context is failed on each step and throw `:early_return` if detect one. 

So we have two issues here: 
- duplicating part of Context#fail! behavior here;
- possible obstacles for permitting failures for certain interactors in a chain.

### Docs

I postponed updating internal methods' documentation until we come to an agreement about proposed changes.

I'll be happy to discuss this!

P.S. integration specs pass without changes, thus external behavior didn't change. I think it's a big win 😄 