### PR TITLE
Add mapping between interactor in an organizer

### DIFF
--- a/lib/interactor/organizer.rb
+++ b/lib/interactor/organizer.rb
@@ -76,7 +76,8 @@ module Interactor
       # Returns nothing.
       def call
         self.class.organized.each do |interactor|
-          interactor.call!(context)
+          self.send(interactor) if interactor.is_a?(Symbol)
+          interactor.call!(context) unless interactor.is_a?(Symbol)
         end
       end
     end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -43,7 +43,7 @@ describe "Integration" do
   }
 
   let(:organizer2) {
-    build_organizer(organize: [interactor2a, interactor2b, interactor2c]) do
+    build_organizer(organize: [interactor2a, :between_2a_2b, interactor2b, interactor2c]) do
       around do |interactor|
         context.steps << :around_before2
         interactor.call
@@ -56,6 +56,10 @@ describe "Integration" do
 
       after do
         context.steps << :after2
+      end
+
+      def between_2a_2b
+        context.steps << :between_2a_2b
       end
     end
   }
@@ -298,6 +302,7 @@ describe "Integration" do
         :around_before, :before,
           :around_before2, :before2,
             :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
+            :between_2a_2b,
             :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
             :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
           :after2, :around_after2,
@@ -476,6 +481,7 @@ describe "Integration" do
         :around_before, :before,
           :around_before2, :before2,
             :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
+            :between_2a_2b,
             :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
             :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
           :after2, :around_after2,
@@ -527,6 +533,7 @@ describe "Integration" do
         :around_before, :before,
           :around_before2, :before2,
             :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
+            :between_2a_2b,
             :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
             :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
           :after2, :around_after2,
@@ -584,6 +591,7 @@ describe "Integration" do
         :around_before, :before,
           :around_before2, :before2,
             :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
+            :between_2a_2b,
             :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
             :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
           :after2, :around_after2,
@@ -636,6 +644,7 @@ describe "Integration" do
         :around_before, :before,
           :around_before2, :before2,
             :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
+            :between_2a_2b,
             :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
             :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
           :after2, :around_after2,
@@ -702,6 +711,7 @@ describe "Integration" do
         :around_before, :before,
           :around_before2, :before2,
             :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
+            :between_2a_2b,
             :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
             :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
           :after2, :around_after2,
@@ -749,6 +759,7 @@ describe "Integration" do
         :around_before, :before,
           :around_before2, :before2,
             :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
+            :between_2a_2b,
             :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
             :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
           :after2, :around_after2,
@@ -802,6 +813,7 @@ describe "Integration" do
         :around_before, :before,
           :around_before2, :before2,
             :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
+            :between_2a_2b,
             :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
             :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
           :after2, :around_after2,
@@ -850,6 +862,7 @@ describe "Integration" do
         :around_before, :before,
           :around_before2, :before2,
             :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
+            :between_2a_2b,
             :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
             :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
           :after2, :around_after2,
@@ -904,6 +917,7 @@ describe "Integration" do
         :around_before, :before,
           :around_before2, :before2,
             :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
+            :between_2a_2b,
             :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
             :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
           :after2, :around_after2,
@@ -952,6 +966,7 @@ describe "Integration" do
         :around_before, :before,
           :around_before2, :before2,
             :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
+            :between_2a_2b,
             :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
             :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
           :after2, :around_after2,
@@ -1006,6 +1021,7 @@ describe "Integration" do
         :around_before, :before,
           :around_before2, :before2,
             :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
+            :between_2a_2b,
             :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
             :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
           :after2, :around_after2,
@@ -1055,6 +1071,7 @@ describe "Integration" do
         :around_before, :before,
           :around_before2, :before2,
             :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
+            :between_2a_2b,
             :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
             :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
           :after2, :around_after2,
@@ -1110,6 +1127,7 @@ describe "Integration" do
         :around_before, :before,
           :around_before2, :before2,
             :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
+            :between_2a_2b,
             :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
             :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
           :after2, :around_after2,
@@ -1159,6 +1177,7 @@ describe "Integration" do
         :around_before, :before,
           :around_before2, :before2,
             :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
+            :between_2a_2b,
             :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
             :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
           :after2, :around_after2,
@@ -1214,6 +1233,7 @@ describe "Integration" do
         :around_before, :before,
           :around_before2, :before2,
             :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
+            :between_2a_2b,
             :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
             :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
           :after2, :around_after2,
@@ -1266,6 +1286,7 @@ describe "Integration" do
         :around_before, :before,
           :around_before2, :before2,
             :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
+            :between_2a_2b,
             :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
             :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
           :after2, :around_after2,
@@ -1324,6 +1345,7 @@ describe "Integration" do
         :around_before, :before,
           :around_before2, :before2,
             :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
+            :between_2a_2b,
             :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
             :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
           :after2, :around_after2,
@@ -1377,6 +1399,7 @@ describe "Integration" do
         :around_before, :before,
           :around_before2, :before2,
             :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
+            :between_2a_2b,
             :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
             :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
           :after2, :around_after2,
@@ -1436,6 +1459,7 @@ describe "Integration" do
         :around_before, :before,
           :around_before2, :before2,
             :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
+            :between_2a_2b,
             :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
             :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
           :after2, :around_after2,
@@ -1489,6 +1513,7 @@ describe "Integration" do
         :around_before, :before,
           :around_before2, :before2,
             :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
+            :between_2a_2b,
             :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
             :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
           :after2, :around_after2,
@@ -1548,6 +1573,7 @@ describe "Integration" do
         :around_before, :before,
           :around_before2, :before2,
             :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
+            :between_2a_2b,
             :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
             :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
           :after2, :around_after2,
@@ -1602,6 +1628,7 @@ describe "Integration" do
         :around_before, :before,
           :around_before2, :before2,
             :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
+            :between_2a_2b,
             :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
             :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
           :after2, :around_after2,
@@ -1662,6 +1689,7 @@ describe "Integration" do
         :around_before, :before,
           :around_before2, :before2,
             :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
+            :between_2a_2b,
             :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
             :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
           :after2, :around_after2,
@@ -1716,6 +1744,7 @@ describe "Integration" do
         :around_before, :before,
           :around_before2, :before2,
             :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
+            :between_2a_2b,
             :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
             :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
           :after2, :around_after2,

--- a/spec/interactor/organizer_spec.rb
+++ b/spec/interactor/organizer_spec.rb
@@ -41,13 +41,15 @@ module Interactor
       before do
         allow(instance).to receive(:context) { context }
         allow(organizer).to receive(:organized) {
-          [interactor2, interactor3, interactor4]
+          [interactor2, :mapping1, interactor3, :mapping2, interactor4]
         }
       end
 
       it "calls each interactor in order with the context" do
         expect(interactor2).to receive(:call!).once.with(context).ordered
+        expect(instance).to receive(:mapping1).once.with(no_args).ordered
         expect(interactor3).to receive(:call!).once.with(context).ordered
+        expect(instance).to receive(:mapping2).once.with(no_args).ordered
         expect(interactor4).to receive(:call!).once.with(context).ordered
 
         instance.call


### PR DESCRIPTION
I had faced the following situation some times:

I create an organizer with two interactors. Let's say `CreateUser` and `GetValidationForEmail`.
`CreateUser` can have some validations in it and do what it says: creates the user. Its output is `user: { name: 'Peter', email: 'peter@gmail.com' }`.
`GetInfoForEmail` uses an external service to validate the email. Its input is `email`.

The interface of these two interactors do not fit, so I would need to either map the required field into some of the interactors or create an interactor just for it.

I believe this mapping should be in the organizer, since it is responsible for getting the interactors to work together.

I implemented the simplest solution I could think of: using symbols that represents methods in the organizers.
The solution for my example would be something like this
```
organize CreateUser, :map_email, GetValidationForEmail

def map_email
  context.email = context.user[:email]
end
```

What do you think about it?

![](https://m.popkey.co/8beb71/LqQW8.gif)