### PR TITLE
Support conditional execution of organized interactors

### DIFF
--- a/lib/interactor.rb
+++ b/lib/interactor.rb
@@ -1,6 +1,7 @@
 require "interactor/context"
 require "interactor/error"
 require "interactor/hooks"
+require "interactor/organized_interactor"
 require "interactor/organizer"
 
 # Public: Interactor methods. Because Interactor is a module, custom Interactor

--- a/lib/interactor/organized_interactor.rb
+++ b/lib/interactor/organized_interactor.rb
@@ -1,0 +1,40 @@
+module Interactor
+  # Internal: this class allows us to run interactors with regard of given
+  # options, such as :if, :unless, :before, :after
+  class OrganizedInteractor
+    attr_reader :interactor, :options
+
+    def initialize(interactor, options = {})
+      @interactor = interactor
+      @options = options
+    end
+
+    def call!(context, within_organizer)
+      interactor.call!(context) if permitted_to_call?(within_organizer)
+    end
+
+    private
+
+    def permitted_to_call?(organizer)
+      permitted_by_if?(organizer) && permitted_by_unless?(organizer)
+    end
+
+    def permitted_by_if?(organizer)
+      return true unless options[:if]
+      execute_within_organizer(organizer, options[:if])
+    end
+
+    def permitted_by_unless?(organizer)
+      return true unless options[:unless]
+      !execute_within_organizer(organizer, options[:unless])
+    end
+
+    def execute_within_organizer(organizer, symbol_or_proc)
+      if symbol_or_proc.is_a?(Symbol)
+        symbol_or_proc.to_proc.call(organizer)
+      else
+        organizer.instance_exec(&symbol_or_proc)
+      end
+    end
+  end
+end

--- a/lib/interactor/organizer.rb
+++ b/lib/interactor/organizer.rb
@@ -45,8 +45,12 @@ module Interactor
       #   end
       #
       # Returns nothing.
-      def organize(*interactors)
-        organized.concat(interactors.flatten)
+      def organize(*interactors, **options)
+        options_dup = options.dup.freeze
+        organized_interactors = interactors.flatten.map do |interactor|
+          OrganizedInteractor.new(interactor, options_dup)
+        end
+        organized.concat(organized_interactors)
       end
 
       # Internal: An Array of declared Interactors to be invoked.
@@ -76,8 +80,8 @@ module Interactor
       #
       # Returns nothing.
       def call
-        self.class.organized.each do |interactor|
-          interactor.call!(context)
+        self.class.organized.each do |organized_interactor|
+          organized_interactor.call!(context, self)
         end
       end
     end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -1787,4 +1787,39 @@ describe "Integration" do
       ])
     end
   end
+
+  context "when conditions are passed to organize calls" do
+    let(:organizer) { build_organizer }
+
+    it "regard them while running interactors" do
+      organizer.class_eval do
+        def truthy_method
+          true
+        end
+
+        def falsey_method
+          false
+        end
+      end
+      organizer.organize(interactor2a, if: :truthy_method)
+      organizer.organize(interactor2b, if: :falsey_method)
+      organizer.organize(interactor2c, unless: :truthy_method)
+      organizer.organize(interactor3, unless: :falsey_method)
+      organizer.organize(interactor4a, if: -> { truthy_method })
+      organizer.organize(interactor4b, if: -> { falsey_method })
+      organizer.organize(interactor4c, unless: -> { truthy_method })
+      organizer.organize(interactor5, unless: -> { falsey_method })
+
+      expect {
+        organizer.call(context)
+      }.to change {
+        context.steps
+      }.from([]).to([
+        :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
+        :around_before3, :before3, :call3, :after3, :around_after3,
+        :around_before4a, :before4a, :call4a, :after4a, :around_after4a,
+        :around_before5, :before5, :call5, :after5, :around_after5
+      ])
+    end
+  end
 end

--- a/spec/interactor/organized_interactor_spec.rb
+++ b/spec/interactor/organized_interactor_spec.rb
@@ -1,0 +1,85 @@
+require "ostruct"
+
+module Interactor
+  describe OrganizedInteractor do
+    let(:interactor) { double(:interactor, call!: nil) }
+    let(:organizer) { FakeOrganizer.new }
+    let(:context) { double(:context) }
+
+    class FakeOrganizer
+      def context
+        OpenStruct.new(truthy: true, falsey: false)
+      end
+
+      def truthy_method
+        true
+      end
+
+      def falsey_method
+        false
+      end
+    end
+
+    def build_with_options_and_call(options)
+      OrganizedInteractor.new(interactor, options).call!(context, organizer)
+    end
+
+    describe "#call!" do
+      it "runs an interactor" do
+        OrganizedInteractor.new(interactor).call!(context, organizer)
+        expect(interactor).to have_received(:call!).with(context)
+      end
+
+      context "when :if option is a proc" do
+        it "evaluates it within an organizer" do
+          expect(organizer).to receive(:truthy_method).and_call_original
+          build_with_options_and_call(if: -> { truthy_method })
+        end
+
+        it "runs an interactor if proc evaluation was truthy" do
+          build_with_options_and_call(if: -> { context.truthy })
+          expect(interactor).to have_received(:call!)
+        end
+
+        it "doesn't run an interactor if proc evaluation was falsey" do
+          build_with_options_and_call(if: -> { context.falsey })
+          expect(interactor).not_to have_received(:call!)
+        end
+      end
+
+      context "when :unless option is a proc" do
+        it "evaluates it within an organizer" do
+          expect(organizer).to receive(:truthy_method).and_call_original
+          build_with_options_and_call(unless: -> { truthy_method })
+        end
+
+        it "runs an interactor if proc evaluation was falsey" do
+          build_with_options_and_call(unless: -> { context.falsey })
+          expect(interactor).to have_received(:call!)
+        end
+
+        it "doesn't run an interactor if proc evaluation was truthy" do
+          build_with_options_and_call(unless: -> { context.truthy })
+          expect(interactor).not_to have_received(:call!)
+        end
+      end
+
+      context "when :if option is a symbol" do
+        it "treats it as organizer's method name" do
+          expect(organizer).to receive(:truthy_method).and_call_original
+          build_with_options_and_call(if: :truthy_method)
+        end
+
+        it "runs an interactor if method evaluation was truthy" do
+          build_with_options_and_call(if: :truthy_method)
+          expect(interactor).to have_received(:call!)
+        end
+
+        it "doesn't run an interactor if method evaluation was falsey" do
+          build_with_options_and_call(if: :falsey_method)
+          expect(interactor).not_to have_received(:call!)
+        end
+      end
+    end
+  end
+end

--- a/spec/interactor/organizer_spec.rb
+++ b/spec/interactor/organizer_spec.rb
@@ -12,7 +12,7 @@ module Interactor
         expect {
           organizer.organize(interactor2, interactor3)
         }.to change {
-          organizer.organized
+          organizer.organized.map(&:interactor)
         }.from([]).to([interactor2, interactor3])
       end
 
@@ -20,7 +20,7 @@ module Interactor
         expect {
           organizer.organize([interactor2, interactor3])
         }.to change {
-          organizer.organized
+          organizer.organized.map(&:interactor)
         }.from([]).to([interactor2, interactor3])
       end
 
@@ -30,8 +30,22 @@ module Interactor
           organizer.organize(interactor2, interactor3)
           organizer.organize(interactor4)
         }.to change {
-          organizer.organized
+          organizer.organized.map(&:interactor)
         }.from([]).to([interactor2, interactor3, interactor4])
+      end
+
+      it "passes options to organized interactors" do
+        expect(OrganizedInteractor).to receive(:new).with(interactor2, if: :foo)
+        organizer.organize(interactor2, if: :foo)
+      end
+
+      it "duplicates and freezes original options hash" do
+        original_options = { if: :foo }
+        expect(OrganizedInteractor).to receive(:new) do |_, passed_options|
+          expect(passed_options).not_to be(original_options)
+          expect(passed_options).to be_frozen
+        end
+        organizer.organize(interactor2, original_options)
       end
     end
 
@@ -39,26 +53,29 @@ module Interactor
       it "is empty by default" do
         expect(organizer.organized).to eq([])
       end
+
+      it "returns an array of OrganizedInteractors" do
+        organizer.organize(double(:interactor))
+        expect(organizer.organized).to all(be_an(OrganizedInteractor))
+      end
     end
 
     describe "#call" do
       let(:instance) { organizer.new }
       let(:context) { double(:context) }
-      let(:interactor2) { double(:interactor2) }
-      let(:interactor3) { double(:interactor3) }
-      let(:interactor4) { double(:interactor4) }
+      let(:organized_interactor2) { double(:organized_interactor2) }
+      let(:organized_interactor3) { double(:organized_interactor3) }
 
-      before do
+      it "calls each organized interactor in order with the context" do
         allow(instance).to receive(:context) { context }
-        allow(organizer).to receive(:organized) {
-          [interactor2, interactor3, interactor4]
-        }
-      end
+        allow(organizer).to receive(:organized).and_return(
+          [organized_interactor2, organized_interactor3]
+        )
 
-      it "calls each interactor in order with the context" do
-        expect(interactor2).to receive(:call!).once.with(context).ordered
-        expect(interactor3).to receive(:call!).once.with(context).ordered
-        expect(interactor4).to receive(:call!).once.with(context).ordered
+        expect(organized_interactor2)
+          .to receive(:call!).with(context, instance).ordered
+        expect(organized_interactor3)
+          .to receive(:call!).with(context, instance).ordered
 
         instance.call
       end


### PR DESCRIPTION
Fixes #128.
I've decided to create `OrganizedInteractor` class to hold organized interactors along with passed options. This class is also responsible to run interactors with regard of passed options. `:if` and `:unless` are currently supported; you could pass either a symbol or a proc.