### PR TITLE
Travis: CodeClimate usage with after_success

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,4 +30,3 @@ rvm:
 script: bundle exec rspec
 after_success:
   - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then bundle exec codeclimate-test-reporter; fi'
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,5 +28,5 @@ rvm:
   - ruby-head
 script: bundle exec rspec
 after_success:
-  - bundle exec codeclimate-test-reporter
+  - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then bundle exec codeclimate-test-reporter; fi'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ branches:
   only:
     - master
     - v3
+    - fix/build-fail-on-codeclimate
 env:
   global:
     - secure: | # CODECLIMATE_REPO_TOKEN
@@ -28,3 +29,6 @@ rvm:
   - "2.4.0"
   - ruby-head
 script: bundle exec rspec
+after_success:
+  - bundle exec codeclimate-test-reporter
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,12 @@ branches:
     - master
     - v3
 
-# CODECLIMATE_REPO_TOKEN
 env:
   global:
-    - secure: BIemhM273wHZMpuULDMYGPsxYdfw+NMw7IQbOD6gy5r+dha07y9ssTYYE5Gnt1ptAb09lhQ4gexXTr83i6angMrnHgQ1ZX2wfeoZ0FvWDHQht9YkXyiNH+R6odHUeDIYAlUiqLX9nAkklL89Rc22BrHMGGNyuA8Uc5sktW5P/FE=
-language: ruby
+    - secure: | # CODECLIMATE_REPO_TOKEN
+        BIemhM273wHZMpuULDMYGPsxYdfw+NMw7IQbOD6gy5r+dha07y9ssTYYE5Gn
+        t1ptAb09lhQ4gexXTr83i6angMrnHgQ1ZX2wfeoZ0FvWDHQht9YkXyiNH+R6
+        odHUeDIYAlUiqLX9nAkklL89Rc22BrHMGGNyuA8Uc5sktW5P/FE=language: ruby
 matrix:
   allow_failures:
     - rvm: ruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ branches:
   only:
     - master
     - v3
-
 env:
   global:
     - secure: | # CODECLIMATE_REPO_TOKEN

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ branches:
   only:
     - master
     - v3
-    - fix/build-fail-on-codeclimate
 env:
   global:
     - secure: | # CODECLIMATE_REPO_TOKEN

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,11 @@ branches:
   only:
     - master
     - v3
+
+# CODECLIMATE_REPO_TOKEN
 env:
   global:
-    - secure: | # CODECLIMATE_REPO_TOKEN
-        BIemhM273wHZMpuULDMYGPsxYdfw+NMw7IQbOD6gy5r+dha07y9ssTYYE5Gn
-        t1ptAb09lhQ4gexXTr83i6angMrnHgQ1ZX2wfeoZ0FvWDHQht9YkXyiNH+R6
-        odHUeDIYAlUiqLX9nAkklL89Rc22BrHMGGNyuA8Uc5sktW5P/FE=
+    - secure: BIemhM273wHZMpuULDMYGPsxYdfw+NMw7IQbOD6gy5r+dha07y9ssTYYE5Gnt1ptAb09lhQ4gexXTr83i6angMrnHgQ1ZX2wfeoZ0FvWDHQht9YkXyiNH+R6odHUeDIYAlUiqLX9nAkklL89Rc22BrHMGGNyuA8Uc5sktW5P/FE=
 language: ruby
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,8 @@ env:
     - secure: | # CODECLIMATE_REPO_TOKEN
         BIemhM273wHZMpuULDMYGPsxYdfw+NMw7IQbOD6gy5r+dha07y9ssTYYE5Gn
         t1ptAb09lhQ4gexXTr83i6angMrnHgQ1ZX2wfeoZ0FvWDHQht9YkXyiNH+R6
-        odHUeDIYAlUiqLX9nAkklL89Rc22BrHMGGNyuA8Uc5sktW5P/FE=language: ruby
+        odHUeDIYAlUiqLX9nAkklL89Rc22BrHMGGNyuA8Uc5sktW5P/FE=
+language: ruby
 matrix:
   allow_failures:
     - rvm: ruby-head

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 if ENV["CODECLIMATE_REPO_TOKEN"]
-  require "codeclimate-test-reporter"
-  CodeClimate::TestReporter.start
+  require "simplecov"
+  SimpleCov.start
 end
 
 require "interactor"


### PR DESCRIPTION
This PR adds the `after_success` hook to Travis builds, to use the supported way of using CodeClimate.

Read more at https://docs.codeclimate.com/v1.0/docs/travis-ci-ruby-test-coverage.

~Issue: `Cannot post results: environment variable CODECLIMATE_REPO_TOKEN must be set.` Is there a problem with the `secure` ENV var, somehow?~

**Update**: Only send coverage information to CodeClimate if not on a PR.
