### PR TITLE
BYO Context interactor flavor

### DIFF
--- a/lib/interactor.rb
+++ b/lib/interactor.rb
@@ -75,6 +75,14 @@ module Interactor
     def call!(context = {})
       new(context).tap(&:run!).context
     end
+
+    def context_with(klass)
+      @context_class = klass
+    end
+
+    def context_class
+      @context_class
+    end
   end
 
   # Internal: Initialize an Interactor.
@@ -91,7 +99,21 @@ module Interactor
   #   MyInteractor.new
   #   # => #<MyInteractor @context=#<Interactor::Context>>
   def initialize(context = {})
-    @context = Context.build(context)
+    @context = new_context(context)
+  end
+
+  def new_context(context)
+    if context_class
+      context_class.build(context)
+    elsif context.class.respond_to?(:build)
+      context.class.build(context)
+    else
+      Context.build(context)
+    end
+  end
+
+  def context_class
+    self.class.context_class
   end
 
   # Internal: Invoke an interactor instance along with all defined hooks. The

--- a/lib/interactor/context.rb
+++ b/lib/interactor/context.rb
@@ -1,4 +1,4 @@
-require "ostruct"
+require 'ostruct'
 
 module Interactor
   # Public: The object for tracking state of an Interactor's invocation. The
@@ -28,32 +28,39 @@ module Interactor
   #   # => "baz"
   #   context
   #   # => #<Interactor::Context foo="baz" hello="world">
-  class Context < OpenStruct
-    # Internal: Initialize an Interactor::Context or preserve an existing one.
-    # If the argument given is an Interactor::Context, the argument is returned.
-    # Otherwise, a new Interactor::Context is initialized from the provided
-    # hash.
-    #
-    # The "build" method is used during interactor initialization.
-    #
-    # context - A Hash whose key/value pairs are used in initializing a new
-    #           Interactor::Context object. If an existing Interactor::Context
-    #           is given, it is simply returned. (default: {})
-    #
-    # Examples
-    #
-    #   context = Interactor::Context.build(foo: "bar")
-    #   # => #<Interactor::Context foo="bar">
-    #   context.object_id
-    #   # => 2170969340
-    #   context = Interactor::Context.build(context)
-    #   # => #<Interactor::Context foo="bar">
-    #   context.object_id
-    #   # => 2170969340
-    #
-    # Returns the Interactor::Context.
-    def self.build(context = {})
-      self === context ? context : new(context)
+
+  module CommonContext
+    module ClassMethods
+      # Internal: Initialize an Interactor::Context or preserve an existing one.
+      # If the argument given is an Interactor::Context, the argument is returned.
+      # Otherwise, a new Interactor::Context is initialized from the provided
+      # hash.
+      #
+      # The "build" method is used during interactor initialization.
+      #
+      # context - A Hash whose key/value pairs are used in initializing a new
+      #           Interactor::Context object. If an existing Interactor::Context
+      #           is given, it is simply returned. (default: {})
+      #
+      # Examples
+      #
+      #   context = Interactor::Context.build(foo: "bar")
+      #   # => #<Interactor::Context foo="bar">
+      #   context.object_id
+      #   # => 2170969340
+      #   context = Interactor::Context.build(context)
+      #   # => #<Interactor::Context foo="bar">
+      #   context.object_id
+      #   # => 2170969340
+      #
+      # Returns the Interactor::Context.
+      def build(context = {})
+        self === context ? context : new(context)
+      end
+    end
+
+    def self.included(base)
+      base.extend(ClassMethods)
     end
 
     # Public: Whether the Interactor::Context is successful. By default, a new
@@ -177,5 +184,9 @@ module Interactor
     def _called
       @called ||= []
     end
+  end
+
+  class Context < OpenStruct
+    include CommonContext
   end
 end


### PR DESCRIPTION
To me, the context object is by far the weakest part of this gem. First, OpenStruct is notoriously slow, and everyone avoids it if they can. A PORO would be way faster.

But an even bigger deal is the lack of support for contracts, which most of these actor-type gems have nowadays.

This PR, though it's admittedly not fully baked and offered here mainly for feedback, is a very small tweak that lets you declare your own context class inside your interactor.

```ruby
class PostContext
  include Interactor::CommonContext
  attr_accessor :title, :description, :author
  
  def initialize(attrs)
    validate_attrs(attrs)
    update(attrs)
  end

  def update(attrs)
    attrs.each { |k, v| self.send("#{k}=", v) }
  end

  def validate_attrs(attrs)
    raise "Missing title!" unless attrs[:title]
  end
end

class CreatePost
  include Interactor

  context_with PostContext

  def call
    # do stuff
  end
end

create_post = CreatePost.call(title: "Foo", description: "Bar", author: current_user) # works just like normal!
```

The above isn't supposed to be real code -- that `PostContext` object needs to return itself when you call `#modifiable` on it, and it should support the `[], []=` interface, and a few other things related to the fact that the gem expects an `OpenStruct`, but you get the idea.

You can declare a PORO and do your own validation of the context however you like -- go nuts and use `ActiveRecord::Validations` or the `reform` gem or `dry-validation`, or whatever you like to impose a strict shape on the context. This way, the context object is no longer required to be magical and slow.

Thoughts?