### PR TITLE
Add standard gem and apply recommendations

### DIFF
--- a/.standard.yml
+++ b/.standard.yml
@@ -1,1 +1,4 @@
 ruby_version: 2.3.0
+ignore:
+  - 'spec/**/*':
+    - Lint/AmbiguousBlockAssociation

--- a/.standard.yml
+++ b/.standard.yml
@@ -1,0 +1,1 @@
+ruby_version: 2.3.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,4 +32,4 @@ rvm:
   - "2.4"
   - "2.5"
   - ruby-head
-script: bundle exec rspec
+script: bundle exec rake

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@ source "https://rubygems.org"
 
 gemspec
 
+gem "standard"
+
 group :test do
   gem "codeclimate-test-reporter", require: false
   gem "rspec", "~> 3.7"

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Build Status](https://img.shields.io/travis/collectiveidea/interactor/master.svg)](https://travis-ci.org/collectiveidea/interactor)
 [![Maintainability](https://img.shields.io/codeclimate/maintainability/collectiveidea/interactor.svg)](https://codeclimate.com/github/collectiveidea/interactor)
 [![Test Coverage](https://img.shields.io/codeclimate/coverage-letter/collectiveidea/interactor.svg)](https://codeclimate.com/github/collectiveidea/interactor)
+[![Ruby Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://github.com/testdouble/standard)
 
 ## Getting Started
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,7 @@
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
+require "standard/rake"
 
 RSpec::Core::RakeTask.new(:spec)
 
-task default: :spec
+task default: [:standard, :spec]

--- a/interactor.gemspec
+++ b/interactor.gemspec
@@ -1,3 +1,5 @@
+require "English"
+
 Gem::Specification.new do |spec|
   spec.name    = "interactor"
   spec.version = "3.1.1"
@@ -9,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.homepage    = "https://github.com/collectiveidea/interactor"
   spec.license     = "MIT"
 
-  spec.files      = `git ls-files`.split($/)
+  spec.files      = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
   spec.test_files = spec.files.grep(/^spec/)
 
   spec.add_development_dependency "bundler"

--- a/interactor.gemspec
+++ b/interactor.gemspec
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 Gem::Specification.new do |spec|
   spec.name    = "interactor"
   spec.version = "3.1.1"

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -296,19 +296,19 @@ describe "Integration" do
         context.steps
       }.from([]).to([
         :around_before, :before,
-          :around_before2, :before2,
-            :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
-            :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
-            :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
-          :after2, :around_after2,
-          :around_before3, :before3, :call3, :after3, :around_after3,
-          :around_before4, :before4,
-            :around_before4a, :before4a, :call4a, :after4a, :around_after4a,
-            :around_before4b, :before4b, :call4b, :after4b, :around_after4b,
-            :around_before4c, :before4c, :call4c, :after4c, :around_after4c,
-          :after4, :around_after4,
-          :around_before5, :before5, :call5, :after5, :around_after5,
-        :after, :around_after
+        :around_before2, :before2,
+        :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
+        :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
+        :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
+        :after2, :around_after2,
+        :around_before3, :before3, :call3, :after3, :around_after3,
+        :around_before4, :before4,
+        :around_before4a, :before4a, :call4a, :after4a, :around_after4a,
+        :around_before4b, :before4b, :call4b, :after4b, :around_after4b,
+        :around_before4c, :before4c, :call4c, :after4c, :around_after4c,
+        :after4, :around_after4,
+        :around_before5, :before5, :call5, :after5, :around_after5,
+        :after, :around_after,
       ])
     end
   end
@@ -366,7 +366,11 @@ describe "Integration" do
 
     it "aborts" do
       expect {
-        organizer.call(context) rescue nil
+        begin
+          organizer.call(context)
+        rescue
+          nil
+        end
       }.not_to change {
         context.steps
       }
@@ -405,7 +409,7 @@ describe "Integration" do
       }.to change {
         context.steps
       }.from([]).to([
-        :around_before
+        :around_before,
       ])
     end
   end
@@ -432,11 +436,15 @@ describe "Integration" do
 
     it "aborts" do
       expect {
-        organizer.call(context) rescue nil
+        begin
+          organizer.call(context)
+        rescue
+          nil
+        end
       }.to change {
         context.steps
       }.from([]).to([
-        :around_before
+        :around_before,
       ])
     end
 
@@ -474,18 +482,18 @@ describe "Integration" do
         context.steps
       }.from([]).to([
         :around_before, :before,
-          :around_before2, :before2,
-            :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
-            :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
-            :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
-          :after2, :around_after2,
-          :around_before3, :before3, :call3, :after3, :around_after3,
-          :around_before4, :before4,
-            :around_before4a, :before4a, :call4a, :after4a, :around_after4a,
-            :around_before4b, :before4b, :call4b, :after4b, :around_after4b,
-            :around_before4c, :before4c, :call4c, :after4c, :around_after4c,
-          :after4, :around_after4,
-          :around_before5, :before5, :call5, :after5, :around_after5,
+        :around_before2, :before2,
+        :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
+        :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
+        :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
+        :after2, :around_after2,
+        :around_before3, :before3, :call3, :after3, :around_after3,
+        :around_before4, :before4,
+        :around_before4a, :before4a, :call4a, :after4a, :around_after4a,
+        :around_before4b, :before4b, :call4b, :after4b, :around_after4b,
+        :around_before4c, :before4c, :call4c, :after4c, :around_after4c,
+        :after4, :around_after4,
+        :around_before5, :before5, :call5, :after5, :around_after5,
         :rollback5,
         :rollback4c,
         :rollback4b,
@@ -493,7 +501,7 @@ describe "Integration" do
         :rollback3,
         :rollback2c,
         :rollback2b,
-        :rollback2a
+        :rollback2a,
       ])
     end
   end
@@ -520,23 +528,27 @@ describe "Integration" do
 
     it "rolls back successfully called interactors and the failed interactor" do
       expect {
-        organizer.call(context) rescue nil
+        begin
+          organizer.call(context)
+        rescue
+          nil
+        end
       }.to change {
         context.steps
       }.from([]).to([
         :around_before, :before,
-          :around_before2, :before2,
-            :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
-            :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
-            :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
-          :after2, :around_after2,
-          :around_before3, :before3, :call3, :after3, :around_after3,
-          :around_before4, :before4,
-            :around_before4a, :before4a, :call4a, :after4a, :around_after4a,
-            :around_before4b, :before4b, :call4b, :after4b, :around_after4b,
-            :around_before4c, :before4c, :call4c, :after4c, :around_after4c,
-          :after4, :around_after4,
-          :around_before5, :before5, :call5, :after5, :around_after5,
+        :around_before2, :before2,
+        :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
+        :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
+        :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
+        :after2, :around_after2,
+        :around_before3, :before3, :call3, :after3, :around_after3,
+        :around_before4, :before4,
+        :around_before4a, :before4a, :call4a, :after4a, :around_after4a,
+        :around_before4b, :before4b, :call4b, :after4b, :around_after4b,
+        :around_before4c, :before4c, :call4c, :after4c, :around_after4c,
+        :after4, :around_after4,
+        :around_before5, :before5, :call5, :after5, :around_after5,
         :rollback5,
         :rollback4c,
         :rollback4b,
@@ -544,7 +556,7 @@ describe "Integration" do
         :rollback3,
         :rollback2c,
         :rollback2b,
-        :rollback2a
+        :rollback2a,
       ])
     end
 
@@ -582,18 +594,18 @@ describe "Integration" do
         context.steps
       }.from([]).to([
         :around_before, :before,
-          :around_before2, :before2,
-            :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
-            :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
-            :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
-          :after2, :around_after2,
-          :around_before3, :before3, :call3, :after3, :around_after3,
-          :around_before4, :before4,
-            :around_before4a, :before4a, :call4a, :after4a, :around_after4a,
-            :around_before4b, :before4b, :call4b, :after4b, :around_after4b,
-            :around_before4c, :before4c, :call4c, :after4c, :around_after4c,
-          :after4, :around_after4,
-          :around_before5, :before5, :call5, :after5, :around_after5,
+        :around_before2, :before2,
+        :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
+        :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
+        :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
+        :after2, :around_after2,
+        :around_before3, :before3, :call3, :after3, :around_after3,
+        :around_before4, :before4,
+        :around_before4a, :before4a, :call4a, :after4a, :around_after4a,
+        :around_before4b, :before4b, :call4b, :after4b, :around_after4b,
+        :around_before4c, :before4c, :call4c, :after4c, :around_after4c,
+        :after4, :around_after4,
+        :around_before5, :before5, :call5, :after5, :around_after5,
         :after,
         :rollback5,
         :rollback4c,
@@ -602,7 +614,7 @@ describe "Integration" do
         :rollback3,
         :rollback2c,
         :rollback2b,
-        :rollback2a
+        :rollback2a,
       ])
     end
   end
@@ -629,23 +641,27 @@ describe "Integration" do
 
     it "rolls back successfully called interactors and the failed interactor" do
       expect {
-        organizer.call(context) rescue nil
+        begin
+          organizer.call(context)
+        rescue
+          nil
+        end
       }.to change {
         context.steps
       }.from([]).to([
         :around_before, :before,
-          :around_before2, :before2,
-            :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
-            :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
-            :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
-          :after2, :around_after2,
-          :around_before3, :before3, :call3, :after3, :around_after3,
-          :around_before4, :before4,
-            :around_before4a, :before4a, :call4a, :after4a, :around_after4a,
-            :around_before4b, :before4b, :call4b, :after4b, :around_after4b,
-            :around_before4c, :before4c, :call4c, :after4c, :around_after4c,
-          :after4, :around_after4,
-          :around_before5, :before5, :call5, :after5, :around_after5,
+        :around_before2, :before2,
+        :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
+        :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
+        :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
+        :after2, :around_after2,
+        :around_before3, :before3, :call3, :after3, :around_after3,
+        :around_before4, :before4,
+        :around_before4a, :before4a, :call4a, :after4a, :around_after4a,
+        :around_before4b, :before4b, :call4b, :after4b, :around_after4b,
+        :around_before4c, :before4c, :call4c, :after4c, :around_after4c,
+        :after4, :around_after4,
+        :around_before5, :before5, :call5, :after5, :around_after5,
         :after,
         :rollback5,
         :rollback4c,
@@ -654,7 +670,7 @@ describe "Integration" do
         :rollback3,
         :rollback2c,
         :rollback2b,
-        :rollback2a
+        :rollback2a,
       ])
     end
 
@@ -700,14 +716,14 @@ describe "Integration" do
         context.steps
       }.from([]).to([
         :around_before, :before,
-          :around_before2, :before2,
-            :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
-            :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
-            :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
-          :after2, :around_after2,
+        :around_before2, :before2,
+        :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
+        :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
+        :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
+        :after2, :around_after2,
         :rollback2c,
         :rollback2b,
-        :rollback2a
+        :rollback2a,
       ])
     end
   end
@@ -742,19 +758,23 @@ describe "Integration" do
 
     it "rolls back successfully called interactors" do
       expect {
-        organizer.call(context) rescue nil
+        begin
+          organizer.call(context)
+        rescue
+          nil
+        end
       }.to change {
         context.steps
       }.from([]).to([
         :around_before, :before,
-          :around_before2, :before2,
-            :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
-            :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
-            :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
-          :after2, :around_after2,
+        :around_before2, :before2,
+        :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
+        :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
+        :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
+        :after2, :around_after2,
         :rollback2c,
         :rollback2b,
-        :rollback2a
+        :rollback2a,
       ])
     end
 
@@ -800,15 +820,15 @@ describe "Integration" do
         context.steps
       }.from([]).to([
         :around_before, :before,
-          :around_before2, :before2,
-            :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
-            :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
-            :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
-          :after2, :around_after2,
-          :around_before3,
+        :around_before2, :before2,
+        :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
+        :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
+        :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
+        :after2, :around_after2,
+        :around_before3,
         :rollback2c,
         :rollback2b,
-        :rollback2a
+        :rollback2a,
       ])
     end
   end
@@ -843,20 +863,24 @@ describe "Integration" do
 
     it "rolls back successfully called interactors" do
       expect {
-        organizer.call(context) rescue nil
+        begin
+          organizer.call(context)
+        rescue
+          nil
+        end
       }.to change {
         context.steps
       }.from([]).to([
         :around_before, :before,
-          :around_before2, :before2,
-            :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
-            :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
-            :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
-          :after2, :around_after2,
-          :around_before3,
+        :around_before2, :before2,
+        :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
+        :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
+        :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
+        :after2, :around_after2,
+        :around_before3,
         :rollback2c,
         :rollback2b,
-        :rollback2a
+        :rollback2a,
       ])
     end
 
@@ -902,15 +926,15 @@ describe "Integration" do
         context.steps
       }.from([]).to([
         :around_before, :before,
-          :around_before2, :before2,
-            :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
-            :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
-            :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
-          :after2, :around_after2,
-          :around_before3, :before3,
+        :around_before2, :before2,
+        :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
+        :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
+        :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
+        :after2, :around_after2,
+        :around_before3, :before3,
         :rollback2c,
         :rollback2b,
-        :rollback2a
+        :rollback2a,
       ])
     end
   end
@@ -945,20 +969,24 @@ describe "Integration" do
 
     it "rolls back successfully called interactors" do
       expect {
-        organizer.call(context) rescue nil
+        begin
+          organizer.call(context)
+        rescue
+          nil
+        end
       }.to change {
         context.steps
       }.from([]).to([
         :around_before, :before,
-          :around_before2, :before2,
-            :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
-            :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
-            :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
-          :after2, :around_after2,
-          :around_before3, :before3,
+        :around_before2, :before2,
+        :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
+        :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
+        :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
+        :after2, :around_after2,
+        :around_before3, :before3,
         :rollback2c,
         :rollback2b,
-        :rollback2a
+        :rollback2a,
       ])
     end
 
@@ -1004,16 +1032,16 @@ describe "Integration" do
         context.steps
       }.from([]).to([
         :around_before, :before,
-          :around_before2, :before2,
-            :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
-            :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
-            :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
-          :after2, :around_after2,
-          :around_before3, :before3, :call3,
+        :around_before2, :before2,
+        :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
+        :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
+        :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
+        :after2, :around_after2,
+        :around_before3, :before3, :call3,
         :rollback3,
         :rollback2c,
         :rollback2b,
-        :rollback2a
+        :rollback2a,
       ])
     end
   end
@@ -1048,21 +1076,25 @@ describe "Integration" do
 
     it "rolls back successfully called interactors and the failed interactor" do
       expect {
-        organizer.call(context) rescue nil
+        begin
+          organizer.call(context)
+        rescue
+          nil
+        end
       }.to change {
         context.steps
       }.from([]).to([
         :around_before, :before,
-          :around_before2, :before2,
-            :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
-            :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
-            :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
-          :after2, :around_after2,
-          :around_before3, :before3, :call3,
+        :around_before2, :before2,
+        :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
+        :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
+        :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
+        :after2, :around_after2,
+        :around_before3, :before3, :call3,
         :rollback3,
         :rollback2c,
         :rollback2b,
-        :rollback2a
+        :rollback2a,
       ])
     end
 
@@ -1108,16 +1140,16 @@ describe "Integration" do
         context.steps
       }.from([]).to([
         :around_before, :before,
-          :around_before2, :before2,
-            :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
-            :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
-            :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
-          :after2, :around_after2,
-          :around_before3, :before3, :call3, :after3,
+        :around_before2, :before2,
+        :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
+        :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
+        :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
+        :after2, :around_after2,
+        :around_before3, :before3, :call3, :after3,
         :rollback3,
         :rollback2c,
         :rollback2b,
-        :rollback2a
+        :rollback2a,
       ])
     end
   end
@@ -1152,21 +1184,25 @@ describe "Integration" do
 
     it "rolls back successfully called interactors and the failed interactor" do
       expect {
-        organizer.call(context) rescue nil
+        begin
+          organizer.call(context)
+        rescue
+          nil
+        end
       }.to change {
         context.steps
       }.from([]).to([
         :around_before, :before,
-          :around_before2, :before2,
-            :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
-            :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
-            :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
-          :after2, :around_after2,
-          :around_before3, :before3, :call3, :after3,
+        :around_before2, :before2,
+        :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
+        :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
+        :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
+        :after2, :around_after2,
+        :around_before3, :before3, :call3, :after3,
         :rollback3,
         :rollback2c,
         :rollback2b,
-        :rollback2a
+        :rollback2a,
       ])
     end
 
@@ -1212,19 +1248,19 @@ describe "Integration" do
         context.steps
       }.from([]).to([
         :around_before, :before,
-          :around_before2, :before2,
-            :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
-            :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
-            :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
-          :after2, :around_after2,
-          :around_before3, :before3, :call3, :after3, :around_after3,
-          :around_before4, :before4,
-            :around_before4a, :before4a, :call4a, :after4a, :around_after4a,
+        :around_before2, :before2,
+        :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
+        :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
+        :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
+        :after2, :around_after2,
+        :around_before3, :before3, :call3, :after3, :around_after3,
+        :around_before4, :before4,
+        :around_before4a, :before4a, :call4a, :after4a, :around_after4a,
         :rollback4a,
         :rollback3,
         :rollback2c,
         :rollback2b,
-        :rollback2a
+        :rollback2a,
       ])
     end
   end
@@ -1259,24 +1295,28 @@ describe "Integration" do
 
     it "rolls back successfully called interactors" do
       expect {
-        organizer.call(context) rescue nil
+        begin
+          organizer.call(context)
+        rescue
+          nil
+        end
       }.to change {
         context.steps
       }.from([]).to([
         :around_before, :before,
-          :around_before2, :before2,
-            :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
-            :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
-            :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
-          :after2, :around_after2,
-          :around_before3, :before3, :call3, :after3, :around_after3,
-          :around_before4, :before4,
-            :around_before4a, :before4a, :call4a, :after4a, :around_after4a,
+        :around_before2, :before2,
+        :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
+        :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
+        :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
+        :after2, :around_after2,
+        :around_before3, :before3, :call3, :after3, :around_after3,
+        :around_before4, :before4,
+        :around_before4a, :before4a, :call4a, :after4a, :around_after4a,
         :rollback4a,
         :rollback3,
         :rollback2c,
         :rollback2b,
-        :rollback2a
+        :rollback2a,
       ])
     end
 
@@ -1322,20 +1362,20 @@ describe "Integration" do
         context.steps
       }.from([]).to([
         :around_before, :before,
-          :around_before2, :before2,
-            :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
-            :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
-            :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
-          :after2, :around_after2,
-          :around_before3, :before3, :call3, :after3, :around_after3,
-          :around_before4, :before4,
-            :around_before4a, :before4a, :call4a, :after4a, :around_after4a,
-            :around_before4b,
+        :around_before2, :before2,
+        :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
+        :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
+        :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
+        :after2, :around_after2,
+        :around_before3, :before3, :call3, :after3, :around_after3,
+        :around_before4, :before4,
+        :around_before4a, :before4a, :call4a, :after4a, :around_after4a,
+        :around_before4b,
         :rollback4a,
         :rollback3,
         :rollback2c,
         :rollback2b,
-        :rollback2a
+        :rollback2a,
       ])
     end
   end
@@ -1370,25 +1410,29 @@ describe "Integration" do
 
     it "rolls back successfully called interactors" do
       expect {
-        organizer.call(context) rescue nil
+        begin
+          organizer.call(context)
+        rescue
+          nil
+        end
       }.to change {
         context.steps
       }.from([]).to([
         :around_before, :before,
-          :around_before2, :before2,
-            :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
-            :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
-            :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
-          :after2, :around_after2,
-          :around_before3, :before3, :call3, :after3, :around_after3,
-          :around_before4, :before4,
-            :around_before4a, :before4a, :call4a, :after4a, :around_after4a,
-            :around_before4b,
+        :around_before2, :before2,
+        :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
+        :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
+        :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
+        :after2, :around_after2,
+        :around_before3, :before3, :call3, :after3, :around_after3,
+        :around_before4, :before4,
+        :around_before4a, :before4a, :call4a, :after4a, :around_after4a,
+        :around_before4b,
         :rollback4a,
         :rollback3,
         :rollback2c,
         :rollback2b,
-        :rollback2a
+        :rollback2a,
       ])
     end
 
@@ -1434,20 +1478,20 @@ describe "Integration" do
         context.steps
       }.from([]).to([
         :around_before, :before,
-          :around_before2, :before2,
-            :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
-            :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
-            :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
-          :after2, :around_after2,
-          :around_before3, :before3, :call3, :after3, :around_after3,
-          :around_before4, :before4,
-            :around_before4a, :before4a, :call4a, :after4a, :around_after4a,
-            :around_before4b, :before4b,
+        :around_before2, :before2,
+        :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
+        :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
+        :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
+        :after2, :around_after2,
+        :around_before3, :before3, :call3, :after3, :around_after3,
+        :around_before4, :before4,
+        :around_before4a, :before4a, :call4a, :after4a, :around_after4a,
+        :around_before4b, :before4b,
         :rollback4a,
         :rollback3,
         :rollback2c,
         :rollback2b,
-        :rollback2a
+        :rollback2a,
       ])
     end
   end
@@ -1482,25 +1526,29 @@ describe "Integration" do
 
     it "rolls back successfully called interactors" do
       expect {
-        organizer.call(context) rescue nil
+        begin
+          organizer.call(context)
+        rescue
+          nil
+        end
       }.to change {
         context.steps
       }.from([]).to([
         :around_before, :before,
-          :around_before2, :before2,
-            :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
-            :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
-            :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
-          :after2, :around_after2,
-          :around_before3, :before3, :call3, :after3, :around_after3,
-          :around_before4, :before4,
-            :around_before4a, :before4a, :call4a, :after4a, :around_after4a,
-            :around_before4b, :before4b,
+        :around_before2, :before2,
+        :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
+        :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
+        :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
+        :after2, :around_after2,
+        :around_before3, :before3, :call3, :after3, :around_after3,
+        :around_before4, :before4,
+        :around_before4a, :before4a, :call4a, :after4a, :around_after4a,
+        :around_before4b, :before4b,
         :rollback4a,
         :rollback3,
         :rollback2c,
         :rollback2b,
-        :rollback2a
+        :rollback2a,
       ])
     end
 
@@ -1546,21 +1594,21 @@ describe "Integration" do
         context.steps
       }.from([]).to([
         :around_before, :before,
-          :around_before2, :before2,
-            :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
-            :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
-            :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
-          :after2, :around_after2,
-          :around_before3, :before3, :call3, :after3, :around_after3,
-          :around_before4, :before4,
-            :around_before4a, :before4a, :call4a, :after4a, :around_after4a,
-            :around_before4b, :before4b, :call4b,
+        :around_before2, :before2,
+        :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
+        :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
+        :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
+        :after2, :around_after2,
+        :around_before3, :before3, :call3, :after3, :around_after3,
+        :around_before4, :before4,
+        :around_before4a, :before4a, :call4a, :after4a, :around_after4a,
+        :around_before4b, :before4b, :call4b,
         :rollback4b,
         :rollback4a,
         :rollback3,
         :rollback2c,
         :rollback2b,
-        :rollback2a
+        :rollback2a,
       ])
     end
   end
@@ -1595,26 +1643,30 @@ describe "Integration" do
 
     it "rolls back successfully called interactors and the failed interactor" do
       expect {
-        organizer.call(context) rescue nil
+        begin
+          organizer.call(context)
+        rescue
+          nil
+        end
       }.to change {
         context.steps
       }.from([]).to([
         :around_before, :before,
-          :around_before2, :before2,
-            :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
-            :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
-            :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
-          :after2, :around_after2,
-          :around_before3, :before3, :call3, :after3, :around_after3,
-          :around_before4, :before4,
-            :around_before4a, :before4a, :call4a, :after4a, :around_after4a,
-            :around_before4b, :before4b, :call4b,
+        :around_before2, :before2,
+        :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
+        :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
+        :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
+        :after2, :around_after2,
+        :around_before3, :before3, :call3, :after3, :around_after3,
+        :around_before4, :before4,
+        :around_before4a, :before4a, :call4a, :after4a, :around_after4a,
+        :around_before4b, :before4b, :call4b,
         :rollback4b,
         :rollback4a,
         :rollback3,
         :rollback2c,
         :rollback2b,
-        :rollback2a
+        :rollback2a,
       ])
     end
 
@@ -1660,21 +1712,21 @@ describe "Integration" do
         context.steps
       }.from([]).to([
         :around_before, :before,
-          :around_before2, :before2,
-            :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
-            :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
-            :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
-          :after2, :around_after2,
-          :around_before3, :before3, :call3, :after3, :around_after3,
-          :around_before4, :before4,
-            :around_before4a, :before4a, :call4a, :after4a, :around_after4a,
-            :around_before4b, :before4b, :call4b, :after4b,
+        :around_before2, :before2,
+        :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
+        :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
+        :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
+        :after2, :around_after2,
+        :around_before3, :before3, :call3, :after3, :around_after3,
+        :around_before4, :before4,
+        :around_before4a, :before4a, :call4a, :after4a, :around_after4a,
+        :around_before4b, :before4b, :call4b, :after4b,
         :rollback4b,
         :rollback4a,
         :rollback3,
         :rollback2c,
         :rollback2b,
-        :rollback2a
+        :rollback2a,
       ])
     end
   end
@@ -1709,26 +1761,30 @@ describe "Integration" do
 
     it "rolls back successfully called interactors and the failed interactor" do
       expect {
-        organizer.call(context) rescue nil
+        begin
+          organizer.call(context)
+        rescue
+          nil
+        end
       }.to change {
         context.steps
       }.from([]).to([
         :around_before, :before,
-          :around_before2, :before2,
-            :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
-            :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
-            :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
-          :after2, :around_after2,
-          :around_before3, :before3, :call3, :after3, :around_after3,
-          :around_before4, :before4,
-            :around_before4a, :before4a, :call4a, :after4a, :around_after4a,
-            :around_before4b, :before4b, :call4b, :after4b,
+        :around_before2, :before2,
+        :around_before2a, :before2a, :call2a, :after2a, :around_after2a,
+        :around_before2b, :before2b, :call2b, :after2b, :around_after2b,
+        :around_before2c, :before2c, :call2c, :after2c, :around_after2c,
+        :after2, :around_after2,
+        :around_before3, :before3, :call3, :after3, :around_after3,
+        :around_before4, :before4,
+        :around_before4a, :before4a, :call4a, :after4a, :around_after4a,
+        :around_before4b, :before4b, :call4b, :after4b,
         :rollback4b,
         :rollback4a,
         :rollback3,
         :rollback2c,
         :rollback2b,
-        :rollback2a
+        :rollback2a,
       ])
     end
 

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -348,9 +348,6 @@ describe "Integration" do
       build_organizer(organize: [organizer2, interactor3, organizer4, interactor5]) do
         around do |interactor|
           raise "foo"
-          context.steps << :around_before
-          interactor.call
-          context.steps << :around_after
         end
 
         before do
@@ -425,7 +422,6 @@ describe "Integration" do
 
         before do
           raise "foo"
-          context.steps << :before
         end
 
         after do
@@ -521,7 +517,6 @@ describe "Integration" do
 
         after do
           raise "foo"
-          context.steps << :after
         end
       end
     }
@@ -626,7 +621,6 @@ describe "Integration" do
           context.steps << :around_before
           interactor.call
           raise "foo"
-          context.steps << :around_after
         end
 
         before do
@@ -733,9 +727,6 @@ describe "Integration" do
       build_interactor do
         around do |interactor|
           raise "foo"
-          context.steps << :around_before3
-          interactor.call
-          context.steps << :around_after3
         end
 
         before do
@@ -844,7 +835,6 @@ describe "Integration" do
 
         before do
           raise "foo"
-          context.steps << :before3
         end
 
         after do
@@ -958,7 +948,6 @@ describe "Integration" do
 
         def call
           raise "foo"
-          context.steps << :call3
         end
 
         def rollback
@@ -1061,7 +1050,6 @@ describe "Integration" do
 
         after do
           raise "foo"
-          context.steps << :after3
         end
 
         def call
@@ -1161,7 +1149,6 @@ describe "Integration" do
           context.steps << :around_before3
           interactor.call
           raise "foo"
-          context.steps << :around_after3
         end
 
         before do
@@ -1270,9 +1257,6 @@ describe "Integration" do
       build_interactor do
         around do |interactor|
           raise "foo"
-          context.steps << :around_before4b
-          interactor.call
-          context.steps << :around_after4b
         end
 
         before do
@@ -1391,7 +1375,6 @@ describe "Integration" do
 
         before do
           raise "foo"
-          context.steps << :before4b
         end
 
         after do
@@ -1515,7 +1498,6 @@ describe "Integration" do
 
         def call
           raise "foo"
-          context.steps << :call4b
         end
 
         def rollback
@@ -1628,7 +1610,6 @@ describe "Integration" do
 
         after do
           raise "foo"
-          context.steps << :after4b
         end
 
         def call
@@ -1738,7 +1719,6 @@ describe "Integration" do
           context.steps << :around_before4b
           interactor.call
           raise "foo"
-          context.steps << :around_after4b
         end
 
         before do

--- a/spec/interactor/context_spec.rb
+++ b/spec/interactor/context_spec.rb
@@ -16,7 +16,7 @@ module Interactor
       end
 
       it "doesn't affect the original hash" do
-        hash = { foo: "bar" }
+        hash = {foo: "bar"}
         context = Context.build(hash)
 
         expect(context).to be_a(Context)
@@ -61,7 +61,11 @@ module Interactor
 
       it "sets success to false" do
         expect {
-          context.fail! rescue nil
+          begin
+            context.fail!
+          rescue
+            nil
+          end
         }.to change {
           context.success?
         }.from(true).to(false)
@@ -69,17 +73,29 @@ module Interactor
 
       it "sets failure to true" do
         expect {
-          context.fail! rescue nil
+          begin
+            context.fail!
+          rescue
+            nil
+          end
         }.to change {
           context.failure?
         }.from(false).to(true)
       end
 
       it "preserves failure" do
-        context.fail! rescue nil
+        begin
+          context.fail!
+        rescue
+          nil
+        end
 
         expect {
-          context.fail! rescue nil
+          begin
+            context.fail!
+          rescue
+            nil
+          end
         }.not_to change {
           context.failure?
         }
@@ -87,7 +103,11 @@ module Interactor
 
       it "preserves the context" do
         expect {
-          context.fail! rescue nil
+          begin
+            context.fail!
+          rescue
+            nil
+          end
         }.not_to change {
           context.foo
         }
@@ -95,7 +115,11 @@ module Interactor
 
       it "updates the context" do
         expect {
-          context.fail!(foo: "baz") rescue nil
+          begin
+            context.fail!(foo: "baz")
+          rescue
+            nil
+          end
         }.to change {
           context.foo
         }.from("bar").to("baz")
@@ -103,7 +127,11 @@ module Interactor
 
       it "updates the context with a string key" do
         expect {
-          context.fail!("foo" => "baz") rescue nil
+          begin
+            context.fail!("foo" => "baz")
+          rescue
+            nil
+          end
         }.to change {
           context.foo
         }.from("bar").to("baz")

--- a/spec/interactor/hooks_spec.rb
+++ b/spec/interactor/hooks_spec.rb
@@ -43,7 +43,7 @@ module Interactor
           expect(hooked.process).to eq([
             :around_before,
             :process,
-            :around_after
+            :around_after,
           ])
         end
       end
@@ -63,7 +63,7 @@ module Interactor
           expect(hooked.process).to eq([
             :around_before,
             :process,
-            :around_after
+            :around_after,
           ])
         end
       end
@@ -93,7 +93,7 @@ module Interactor
             :around_before2,
             :process,
             :around_after2,
-            :around_after1
+            :around_after1,
           ])
         end
       end
@@ -125,7 +125,7 @@ module Interactor
             :around_before2,
             :process,
             :around_after2,
-            :around_after1
+            :around_after1,
           ])
         end
       end
@@ -146,7 +146,7 @@ module Interactor
         it "runs the before hook method" do
           expect(hooked.process).to eq([
             :before,
-            :process
+            :process,
           ])
         end
       end
@@ -163,7 +163,7 @@ module Interactor
         it "runs the before hook block" do
           expect(hooked.process).to eq([
             :before,
-            :process
+            :process,
           ])
         end
       end
@@ -187,7 +187,7 @@ module Interactor
           expect(hooked.process).to eq([
             :before1,
             :before2,
-            :process
+            :process,
           ])
         end
       end
@@ -213,7 +213,7 @@ module Interactor
           expect(hooked.process).to eq([
             :before1,
             :before2,
-            :process
+            :process,
           ])
         end
       end
@@ -234,7 +234,7 @@ module Interactor
         it "runs the after hook method" do
           expect(hooked.process).to eq([
             :process,
-            :after
+            :after,
           ])
         end
       end
@@ -251,7 +251,7 @@ module Interactor
         it "runs the after hook block" do
           expect(hooked.process).to eq([
             :process,
-            :after
+            :after,
           ])
         end
       end
@@ -275,7 +275,7 @@ module Interactor
           expect(hooked.process).to eq([
             :process,
             :after2,
-            :after1
+            :after1,
           ])
         end
       end
@@ -301,7 +301,7 @@ module Interactor
           expect(hooked.process).to eq([
             :process,
             :after2,
-            :after1
+            :after1,
           ])
         end
       end
@@ -349,7 +349,7 @@ module Interactor
             :after2,
             :after1,
             :around_after2,
-            :around_after1
+            :around_after1,
           ])
         end
       end


### PR DESCRIPTION
I've been adding [standard](https://github.com/testdouble/standard) to a lot of projects lately, and I appreciate the recommendations.

I applied automatic changes (`rake standard:fix`) and then worked through other recommendations. 

It exposed a bunch of unreachable code in `spec/integration_spec.rb` which may be worth looking at. 

Finally, I added it to the default rake task so it'll error if the code isn't standard. 

Let me know what you think, and I won't be offended if you reject this PR. 