### PR TITLE
Make the Context class swapable

### DIFF
--- a/interactor.gemspec
+++ b/interactor.gemspec
@@ -1,17 +1,17 @@
 require "English"
 
 Gem::Specification.new do |spec|
-  spec.name    = "interactor"
+  spec.name = "interactor"
   spec.version = "3.1.1"
 
-  spec.author      = "Collective Idea"
-  spec.email       = "info@collectiveidea.com"
+  spec.author = "Collective Idea"
+  spec.email = "info@collectiveidea.com"
   spec.description = "Interactor provides a common interface for performing complex user interactions."
-  spec.summary     = "Simple interactor implementation"
-  spec.homepage    = "https://github.com/collectiveidea/interactor"
-  spec.license     = "MIT"
+  spec.summary = "Simple interactor implementation"
+  spec.homepage = "https://github.com/collectiveidea/interactor"
+  spec.license = "MIT"
 
-  spec.files      = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
+  spec.files = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
   spec.test_files = spec.files.grep(/^spec/)
 
   spec.add_development_dependency "bundler"

--- a/lib/interactor.rb
+++ b/lib/interactor.rb
@@ -75,6 +75,14 @@ module Interactor
     def call!(context = {})
       new(context).tap(&:run!).context
     end
+
+    def context_class
+      @context_class || Interactor::Context
+    end
+
+    def context_class=(klass)
+      @context_class = klass
+    end
   end
 
   # Internal: Initialize an Interactor.
@@ -91,7 +99,7 @@ module Interactor
   #   MyInteractor.new
   #   # => #<MyInteractor @context=#<Interactor::Context>>
   def initialize(context = {})
-    @context = Context.build(context)
+    @context = self.class.context_class.build(context)
   end
 
   # Internal: Invoke an interactor instance along with all defined hooks. The

--- a/lib/interactor/context.rb
+++ b/lib/interactor/context.rb
@@ -29,153 +29,166 @@ module Interactor
   #   context
   #   # => #<Interactor::Context foo="baz" hello="world">
   class Context < OpenStruct
-    # Internal: Initialize an Interactor::Context or preserve an existing one.
-    # If the argument given is an Interactor::Context, the argument is returned.
-    # Otherwise, a new Interactor::Context is initialized from the provided
-    # hash.
-    #
-    # The "build" method is used during interactor initialization.
-    #
-    # context - A Hash whose key/value pairs are used in initializing a new
-    #           Interactor::Context object. If an existing Interactor::Context
-    #           is given, it is simply returned. (default: {})
-    #
-    # Examples
-    #
-    #   context = Interactor::Context.build(foo: "bar")
-    #   # => #<Interactor::Context foo="bar">
-    #   context.object_id
-    #   # => 2170969340
-    #   context = Interactor::Context.build(context)
-    #   # => #<Interactor::Context foo="bar">
-    #   context.object_id
-    #   # => 2170969340
-    #
-    # Returns the Interactor::Context.
-    def self.build(context = {})
-      self === context ? context : new(context)
+    module Mixin
+      def self.included(receiver)
+        receiver.extend         ClassMethods
+        receiver.send :include, InstanceMethods
+      end
+
+      module ClassMethods
+        # Internal: Initialize an Interactor::Context or preserve an existing one.
+        # If the argument given is an Interactor::Context, the argument is returned.
+        # Otherwise, a new Interactor::Context is initialized from the provided
+        # hash.
+        #
+        # The "build" method is used during interactor initialization.
+        #
+        # context - A Hash whose key/value pairs are used in initializing a new
+        #           Interactor::Context object. If an existing Interactor::Context
+        #           is given, it is simply returned. (default: {})
+        #
+        # Examples
+        #
+        #   context = Interactor::Context.build(foo: "bar")
+        #   # => #<Interactor::Context foo="bar">
+        #   context.object_id
+        #   # => 2170969340
+        #   context = Interactor::Context.build(context)
+        #   # => #<Interactor::Context foo="bar">
+        #   context.object_id
+        #   # => 2170969340
+        #
+        # Returns the Interactor::Context.
+        def build(context = {})
+          self === context ? context : new(context)
+        end
+      end
+
+      module InstanceMethods
+        # Public: Whether the Interactor::Context is successful. By default, a new
+        # context is successful and only changes when explicitly failed.
+        #
+        # The "success?" method is the inverse of the "failure?" method.
+        #
+        # Examples
+        #
+        #   context = Interactor::Context.new
+        #   # => #<Interactor::Context>
+        #   context.success?
+        #   # => true
+        #   context.fail!
+        #   # => Interactor::Failure: #<Interactor::Context>
+        #   context.success?
+        #   # => false
+        #
+        # Returns true by default or false if failed.
+        def success?
+          !failure?
+        end
+
+        # Public: Whether the Interactor::Context has failed. By default, a new
+        # context is successful and only changes when explicitly failed.
+        #
+        # The "failure?" method is the inverse of the "success?" method.
+        #
+        # Examples
+        #
+        #   context = Interactor::Context.new
+        #   # => #<Interactor::Context>
+        #   context.failure?
+        #   # => false
+        #   context.fail!
+        #   # => Interactor::Failure: #<Interactor::Context>
+        #   context.failure?
+        #   # => true
+        #
+        # Returns false by default or true if failed.
+        def failure?
+          @failure || false
+        end
+
+        # Public: Fail the Interactor::Context. Failing a context raises an error
+        # that may be rescued by the calling interactor. The context is also flagged
+        # as having failed.
+        #
+        # Optionally the caller may provide a hash of key/value pairs to be merged
+        # into the context before failure.
+        #
+        # context - A Hash whose key/value pairs are merged into the existing
+        #           Interactor::Context instance. (default: {})
+        #
+        # Examples
+        #
+        #   context = Interactor::Context.new
+        #   # => #<Interactor::Context>
+        #   context.fail!
+        #   # => Interactor::Failure: #<Interactor::Context>
+        #   context.fail! rescue false
+        #   # => false
+        #   context.fail!(foo: "baz")
+        #   # => Interactor::Failure: #<Interactor::Context foo="baz">
+        #
+        # Raises Interactor::Failure initialized with the Interactor::Context.
+        def fail!(context = {})
+          context.each { |key, value| self.send("#{key}=", value) }
+          @failure = true
+          raise Failure, self
+        end
+
+        # Internal: Track that an Interactor has been called. The "called!" method
+        # is used by the interactor being invoked with this context. After an
+        # interactor is successfully called, the interactor instance is tracked in
+        # the context for the purpose of potential future rollback.
+        #
+        # interactor - An Interactor instance that has been successfully called.
+        #
+        # Returns nothing.
+        def called!(interactor)
+          _called << interactor
+        end
+
+        # Public: Roll back the Interactor::Context. Any interactors to which this
+        # context has been passed and which have been successfully called are asked
+        # to roll themselves back by invoking their "rollback" instance methods.
+        #
+        # Examples
+        #
+        #   context = MyInteractor.call(foo: "bar")
+        #   # => #<Interactor::Context foo="baz">
+        #   context.rollback!
+        #   # => true
+        #   context
+        #   # => #<Interactor::Context foo="bar">
+        #
+        # Returns true if rolled back successfully or false if already rolled back.
+        def rollback!
+          return false if @rolled_back
+          _called.reverse_each(&:rollback)
+          @rolled_back = true
+        end
+
+        # Internal: An Array of successfully called Interactor instances invoked
+        # against this Interactor::Context instance.
+        #
+        # Examples
+        #
+        #   context = Interactor::Context.new
+        #   # => #<Interactor::Context>
+        #   context._called
+        #   # => []
+        #
+        #   context = MyInteractor.call(foo: "bar")
+        #   # => #<Interactor::Context foo="baz">
+        #   context._called
+        #   # => [#<MyInteractor @context=#<Interactor::Context foo="baz">>]
+        #
+        # Returns an Array of Interactor instances or an empty Array.
+        def _called
+          @called ||= []
+        end
+      end
     end
 
-    # Public: Whether the Interactor::Context is successful. By default, a new
-    # context is successful and only changes when explicitly failed.
-    #
-    # The "success?" method is the inverse of the "failure?" method.
-    #
-    # Examples
-    #
-    #   context = Interactor::Context.new
-    #   # => #<Interactor::Context>
-    #   context.success?
-    #   # => true
-    #   context.fail!
-    #   # => Interactor::Failure: #<Interactor::Context>
-    #   context.success?
-    #   # => false
-    #
-    # Returns true by default or false if failed.
-    def success?
-      !failure?
-    end
-
-    # Public: Whether the Interactor::Context has failed. By default, a new
-    # context is successful and only changes when explicitly failed.
-    #
-    # The "failure?" method is the inverse of the "success?" method.
-    #
-    # Examples
-    #
-    #   context = Interactor::Context.new
-    #   # => #<Interactor::Context>
-    #   context.failure?
-    #   # => false
-    #   context.fail!
-    #   # => Interactor::Failure: #<Interactor::Context>
-    #   context.failure?
-    #   # => true
-    #
-    # Returns false by default or true if failed.
-    def failure?
-      @failure || false
-    end
-
-    # Public: Fail the Interactor::Context. Failing a context raises an error
-    # that may be rescued by the calling interactor. The context is also flagged
-    # as having failed.
-    #
-    # Optionally the caller may provide a hash of key/value pairs to be merged
-    # into the context before failure.
-    #
-    # context - A Hash whose key/value pairs are merged into the existing
-    #           Interactor::Context instance. (default: {})
-    #
-    # Examples
-    #
-    #   context = Interactor::Context.new
-    #   # => #<Interactor::Context>
-    #   context.fail!
-    #   # => Interactor::Failure: #<Interactor::Context>
-    #   context.fail! rescue false
-    #   # => false
-    #   context.fail!(foo: "baz")
-    #   # => Interactor::Failure: #<Interactor::Context foo="baz">
-    #
-    # Raises Interactor::Failure initialized with the Interactor::Context.
-    def fail!(context = {})
-      context.each { |key, value| modifiable[key.to_sym] = value }
-      @failure = true
-      raise Failure, self
-    end
-
-    # Internal: Track that an Interactor has been called. The "called!" method
-    # is used by the interactor being invoked with this context. After an
-    # interactor is successfully called, the interactor instance is tracked in
-    # the context for the purpose of potential future rollback.
-    #
-    # interactor - An Interactor instance that has been successfully called.
-    #
-    # Returns nothing.
-    def called!(interactor)
-      _called << interactor
-    end
-
-    # Public: Roll back the Interactor::Context. Any interactors to which this
-    # context has been passed and which have been successfully called are asked
-    # to roll themselves back by invoking their "rollback" instance methods.
-    #
-    # Examples
-    #
-    #   context = MyInteractor.call(foo: "bar")
-    #   # => #<Interactor::Context foo="baz">
-    #   context.rollback!
-    #   # => true
-    #   context
-    #   # => #<Interactor::Context foo="bar">
-    #
-    # Returns true if rolled back successfully or false if already rolled back.
-    def rollback!
-      return false if @rolled_back
-      _called.reverse_each(&:rollback)
-      @rolled_back = true
-    end
-
-    # Internal: An Array of successfully called Interactor instances invoked
-    # against this Interactor::Context instance.
-    #
-    # Examples
-    #
-    #   context = Interactor::Context.new
-    #   # => #<Interactor::Context>
-    #   context._called
-    #   # => []
-    #
-    #   context = MyInteractor.call(foo: "bar")
-    #   # => #<Interactor::Context foo="baz">
-    #   context._called
-    #   # => [#<MyInteractor @context=#<Interactor::Context foo="baz">>]
-    #
-    # Returns an Array of Interactor instances or an empty Array.
-    def _called
-      @called ||= []
-    end
+    include Mixin
   end
 end

--- a/lib/interactor/context.rb
+++ b/lib/interactor/context.rb
@@ -31,7 +31,7 @@ module Interactor
   class Context < OpenStruct
     module Mixin
       def self.included(receiver)
-        receiver.extend         ClassMethods
+        receiver.extend ClassMethods
         receiver.send :include, InstanceMethods
       end
 
@@ -130,7 +130,7 @@ module Interactor
         #
         # Raises Interactor::Failure initialized with the Interactor::Context.
         def fail!(context = {})
-          context.each { |key, value| self.send("#{key}=", value) }
+          context.each { |key, value| send("#{key}=", value) }
           @failure = true
           raise Failure, self
         end

--- a/spec/interactor/context_spec.rb
+++ b/spec/interactor/context_spec.rb
@@ -220,7 +220,7 @@ module Interactor
           end
 
           def to_h
-            { foo: foo }
+            {foo: foo}
           end
         end
       end


### PR DESCRIPTION
This allows to have more control on how the context works. For example which attributes are required, it's default values or validation.

Here's a short sample for illustration:

```ruby
class MyInteractor
  include Interactor

  self.context_class = Class.new do
    include Context::Mixin

    attr_reader :foo
    attr_accessor :my_export

    def initialize(foo: nil)
      @foo = foo
    end
  end

  def call
    if context.foo
      context.my_export = "Got: " + context.foo.to_s
    else
      context.fail!(my_export: "Error")
    end
  end
end

puts MyInteractor.call(foo: "Hi").my_export # "Got: Hi"
puts MyInteractor.call.my_export # "Error"
MyInteractor.call(unexpected: "information") # ArgumentError (unknown keyword: unexpected)
```

This PR probably lacks quite some documentation etc. I just wanted to get your input if this is something you'd consider. (Obviously I'm happy to put more work into this if you do)