### PR TITLE
Fix `Interactor::Context#fail!` error on ruby-2.7.0

### DIFF
--- a/lib/interactor/context.rb
+++ b/lib/interactor/context.rb
@@ -121,7 +121,7 @@ module Interactor
     #
     # Raises Interactor::Failure initialized with the Interactor::Context.
     def fail!(context = {})
-      context.each { |key, value| modifiable[key.to_sym] = value }
+      context.each { |key, value| self[key.to_sym] = value }
       @failure = true
       raise Failure, self
     end


### PR DESCRIPTION
In ruby-2.7.0, calling `Interactor::Context#fail!` with non-empty arguments (i.e. an error message) throws `NoMethodError: undefined method `[]=' for nil:NilClass`

`OpenStruct#modifiable` seems to have been removed in ruby-2.7.0