### PR TITLE
Fix typo in organizer example

### DIFF
--- a/lib/interactor/organizer.rb
+++ b/lib/interactor/organizer.rb
@@ -8,7 +8,7 @@ module Interactor
   #   class MyOrganizer
   #     include Interactor::Organizer
   #
-  #     organizer InteractorOne, InteractorTwo
+  #     organize InteractorOne, InteractorTwo
   #   end
   module Organizer
     # Internal: Install Interactor::Organizer's behavior in the given class.


### PR DESCRIPTION
This fixes a method name typo in `Organizer` example.