### PR TITLE
Add support for inheriting hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,6 +470,62 @@ end
 interactor should have a single purpose, there should be no need to clean up
 after any failed interactor.
 
+## Interactor Inheritance
+
+Interactors can inherit from other interactors. Subclasses will inherit hooks declared in ancestors:
+
+```ruby
+class ParentInteractor
+  around do |interactor|
+    puts "around before ancestor"
+    interactor.call
+    puts "around after ancestor"
+  end
+
+  before do
+    puts "before ancestor"
+  end
+
+  after do
+    puts "after ancestor"
+  end
+end
+
+class ChildInteractor < ParentInteractor
+  around do |interactor|
+    puts "around before child"
+    interactor.call
+    puts "around after child"
+  end
+
+  before do
+    puts "before child"
+  end
+
+  after do
+    puts "after child"
+  end
+
+  def call
+    puts "called"
+  end
+end
+```
+
+Calling the child interactor will output:
+
+```
+around before child
+around before parent
+before child
+before parent
+called
+after parent
+after child
+around after parent
+around after child
+```
+
 ## Testing Interactors
 
 When written correctly, an interactor is easy to test because it only *does* one

--- a/lib/interactor/hooks.rb
+++ b/lib/interactor/hooks.rb
@@ -50,7 +50,7 @@ module Interactor
       # Returns nothing.
       def around(*hooks, &block)
         hooks << block if block
-        hooks.each { |hook| around_hooks.push(hook) }
+        hooks.each { |hook| internal_around_hooks.push(hook) }
       end
 
       # Public: Declare hooks to run before Interactor invocation. The before
@@ -87,7 +87,7 @@ module Interactor
       # Returns nothing.
       def before(*hooks, &block)
         hooks << block if block
-        hooks.each { |hook| before_hooks.push(hook) }
+        hooks.each { |hook| internal_before_hooks.push(hook) }
       end
 
       # Public: Declare hooks to run after Interactor invocation. The after
@@ -124,11 +124,12 @@ module Interactor
       # Returns nothing.
       def after(*hooks, &block)
         hooks << block if block
-        hooks.each { |hook| after_hooks.unshift(hook) }
+        hooks.each { |hook| internal_after_hooks.unshift(hook) }
       end
 
       # Internal: An Array of declared hooks to run around Interactor
       # invocation. The hooks appear in the order in which they will be run.
+      # Includes hooks declared in ancestors.
       #
       # Examples
       #
@@ -143,11 +144,12 @@ module Interactor
       #
       # Returns an Array of Symbols and Procs.
       def around_hooks
-        @around_hooks ||= []
+        internal_around_hooks + ancestor_around_hooks
       end
 
       # Internal: An Array of declared hooks to run before Interactor
       # invocation. The hooks appear in the order in which they will be run.
+      # Includes hooks declared in ancestors.
       #
       # Examples
       #
@@ -162,11 +164,12 @@ module Interactor
       #
       # Returns an Array of Symbols and Procs.
       def before_hooks
-        @before_hooks ||= []
+        internal_before_hooks + ancestor_before_hooks
       end
 
-      # Internal: An Array of declared hooks to run before Interactor
+      # Internal: An Array of declared hooks to run after Interactor
       # invocation. The hooks appear in the order in which they will be run.
+      # Includes hooks declared in ancestors.
       #
       # Examples
       #
@@ -181,7 +184,141 @@ module Interactor
       #
       # Returns an Array of Symbols and Procs.
       def after_hooks
-        @after_hooks ||= []
+        ancestor_after_hooks + internal_after_hooks
+      end
+
+      # Internal: An Array of declared hooks to run around Interactor
+      # invocation. The hooks appear in the order in which they will be run.
+      #
+      # Examples
+      #
+      #   class MyInteractor
+      #     include Interactor
+      #
+      #     around :time_execution, :use_transaction
+      #   end
+      #
+      #   MyInteractor.internal_around_hooks
+      #   # => [:time_execution, :use_transaction]
+      #
+      # Returns an Array of Symbols and Procs.
+      def internal_around_hooks
+        @internal_around_hooks ||= []
+      end
+
+      # Internal: An Array of declared hooks to run before Interactor
+      # invocation. The hooks appear in the order in which they will be run.
+      #
+      # Examples
+      #
+      #   class MyInteractor
+      #     include Interactor
+      #
+      #     before :set_start_time, :say_hello
+      #   end
+      #
+      #   MyInteractor.internal_before_hooks
+      #   # => [:set_start_time, :say_hello]
+      #
+      # Returns an Array of Symbols and Procs.
+      def internal_before_hooks
+        @internal_before_hooks ||= []
+      end
+
+      # Internal: An Array of declared hooks to run after Interactor
+      # invocation. The hooks appear in the order in which they will be run.
+      #
+      # Examples
+      #
+      #   class MyInteractor
+      #     include Interactor
+      #
+      #     after :set_finish_time, :say_goodbye
+      #   end
+      #
+      #   MyInteractor.internal_after_hooks
+      #   # => [:say_goodbye, :set_finish_time]
+      #
+      # Returns an Array of Symbols and Procs.
+      def internal_after_hooks
+        @internal_after_hooks ||= []
+      end
+
+      # Internal: An Array of around hooks declared in ancestors.
+      # The hooks appear in the order in which they will be run.
+      #
+      # Examples
+      #
+      #   class MyParentInteractor
+      #     include Interactor
+      #
+      #     around :time_execution, :use_transaction
+      #   end
+      #
+      #   class MyChildInteractor < MyParentInteractor
+      #   end
+      #
+      #   MyChildInteractor.ancestor_around_hooks
+      #   # => [:time_execution, :use_transaction]
+      #
+      # Returns an Array of Symbols and Procs.
+      def ancestor_around_hooks
+        ancestor_hooks(:around_hooks)
+      end
+
+      # Internal: An Array of before hooks declared in ancestors.
+      # The hooks appear in the order in which they will be run.
+      #
+      # Examples
+      #
+      #   class MyParentInteractor
+      #     include Interactor
+      #
+      #     before :set_finish_time, :say_goodbye
+      #   end
+      #
+      #   class MyChildInteractor < MyParentInteractor
+      #   end
+      #
+      #   MyChildInteractor.ancestor_before_hooks
+      #   # => [:set_finish_time, :say_goodbye]
+      #
+      # Returns an Array of Symbols and Procs.
+      def ancestor_before_hooks
+        ancestor_hooks(:before_hooks)
+      end
+
+      # Internal: An Array of after hooks declared in ancestors.
+      # The hooks appear in the order in which they will be run.
+      #
+      # Examples
+      #
+      #   class MyParentInteractor
+      #     include Interactor
+      #
+      #     after :set_finish_time, :say_goodbye
+      #   end
+      #
+      #   class MyChildInteractor < MyParentInteractor
+      #   end
+      #
+      #   MyChildInteractor.ancestor_after_hooks
+      #   # => [:say_goodbye, :set_finish_time]
+      #
+      # Returns an Array of Symbols and Procs.
+      def ancestor_after_hooks
+        ancestor_hooks(:after_hooks)
+      end
+
+      private
+
+      # Internal: Fetches hooks declared in the ancestor.
+      #
+      # name - A Symbol corresponding to the hook method in the ancestor.
+      #
+      # Returns an Array of Symbols and Procs.
+      def ancestor_hooks(name)
+        superclass && superclass.respond_to?(name) ? superclass.send(name) : []
       end
     end
 


### PR DESCRIPTION
This PR implements support for inheriting hooks defined in ancestors.

[A previous PR has also targeted this issue](https://github.com/collectiveidea/interactor/pull/138); however, that solution does not support hooks declared in ancestors at runtime. This solution does:

```ruby
class ParentInteractor
  include Interactor
end

class ChildInteractor < ParentInteractor
end

ParentInteractor.before do
  puts "Before in parent"
end

ChildInteractor.call 
=> "Before in parent"
```

I had to move around the internals of the `Hooks` module a bit to make this work, which might break things, should people attempt to mutate the values of `#around_hooks`, `#before_hooks` and `#after_hooks` in their applications. I hope this is acceptable if we target this fix for the next major version, which seems to be 4.0. 

Let me know if I'm missing anything.

Fixes: #114