### PR TITLE
Don't rescue Failures from other contexts

### DIFF
--- a/lib/interactor.rb
+++ b/lib/interactor.rb
@@ -113,7 +113,10 @@ module Interactor
   # Returns nothing.
   def run
     run!
-  rescue Failure
+  rescue Failure => e
+    if context.object_id != e.context.object_id
+      raise
+    end
   end
 
   # Internal: Invoke an Interactor instance along with all defined hooks. The

--- a/spec/support/lint.rb
+++ b/spec/support/lint.rb
@@ -70,12 +70,20 @@ shared_examples :lint do
       instance.run
     end
 
-    it "rescues failure" do
-      expect(instance).to receive(:run!).and_raise(Interactor::Failure)
+    it "rescues failure with the same context" do
+      expect(instance).to receive(:run!).and_raise(Interactor::Failure.new(instance.context))
 
       expect {
         instance.run
       }.not_to raise_error
+    end
+
+    it "raises other failures" do
+      expect(instance).to receive(:run!).and_raise(Interactor::Failure.new(Interactor::Context.new))
+
+      expect {
+        instance.run
+      }.to raise_error(Interactor::Failure)
     end
 
     it "raises other errors" do


### PR DESCRIPTION
I believe this resolves #170, or at least the portion of it we're running into.

This change modifies the rescue in run to only apply to `Failures` which share the exact same context object. This should allow nesting of `a.run { b.run! }` without a consuming b's Failure.

