### PR TITLE
[TP#37096] Create new context when .fail! is called

### DIFF
--- a/lib/interactor/context.rb
+++ b/lib/interactor/context.rb
@@ -121,9 +121,10 @@ module Interactor
     #
     # Raises Interactor::Failure initialized with the Interactor::Context.
     def fail!(context = {})
-      context.each { |key, value| self[key.to_sym] = value }
-      @failure = true
-      raise Failure, self
+      error_context = Context.new
+      context.each { |key, value| error_context[key.to_sym] = value }
+      error_context.failure = @failure = true
+      raise Failure, error_context
     end
 
     # Internal: Track that an Interactor has been called. The "called!" method


### PR DESCRIPTION
TP#37096
## Overview

This is a blanket fix for the bug that exposes sensitive information to logging systems (i.e. Honey Badger).  This creates a new context when the `.fail!` method is called removing the context that may contain sensitive information.   This still passes any failure message you pass via the `.fail!` method.