### PR TITLE
CI/CD: fixing the build

### DIFF
--- a/.standard.yml
+++ b/.standard.yml
@@ -1,4 +1,4 @@
-ruby_version: 2.3.0
+ruby_version: 2.5
 ignore:
   - 'spec/**/*':
     - Lint/AmbiguousBlockAssociation

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,6 @@ env:
 language: ruby
 matrix:
   allow_failures:
-    - rvm: "2.0"
-    - rvm: "2.1"
-    - rvm: "2.2"
     - rvm: ruby-head
 notifications:
   webhooks:
@@ -25,13 +22,9 @@ notifications:
     urls:
       - http://buildlight.collectiveidea.com/
 rvm:
-  - "2.0"
-  - "2.1"
-  - "2.2"
-  - "2.3"
-  - "2.4"
   - "2.5"
   - "2.6"
   - "2.7"
+  - "3.0"
   - ruby-head
 script: bundle exec rake

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -308,7 +308,7 @@ describe "Integration" do
         :around_before4c, :before4c, :call4c, :after4c, :around_after4c,
         :after4, :around_after4,
         :around_before5, :before5, :call5, :after5, :around_after5,
-        :after, :around_after,
+        :after, :around_after
       ])
     end
   end
@@ -406,7 +406,7 @@ describe "Integration" do
       }.to change {
         context.steps
       }.from([]).to([
-        :around_before,
+        :around_before
       ])
     end
   end
@@ -440,7 +440,7 @@ describe "Integration" do
       }.to change {
         context.steps
       }.from([]).to([
-        :around_before,
+        :around_before
       ])
     end
 
@@ -497,7 +497,7 @@ describe "Integration" do
         :rollback3,
         :rollback2c,
         :rollback2b,
-        :rollback2a,
+        :rollback2a
       ])
     end
   end
@@ -551,7 +551,7 @@ describe "Integration" do
         :rollback3,
         :rollback2c,
         :rollback2b,
-        :rollback2a,
+        :rollback2a
       ])
     end
 
@@ -609,7 +609,7 @@ describe "Integration" do
         :rollback3,
         :rollback2c,
         :rollback2b,
-        :rollback2a,
+        :rollback2a
       ])
     end
   end
@@ -664,7 +664,7 @@ describe "Integration" do
         :rollback3,
         :rollback2c,
         :rollback2b,
-        :rollback2a,
+        :rollback2a
       ])
     end
 
@@ -717,7 +717,7 @@ describe "Integration" do
         :after2, :around_after2,
         :rollback2c,
         :rollback2b,
-        :rollback2a,
+        :rollback2a
       ])
     end
   end
@@ -765,7 +765,7 @@ describe "Integration" do
         :after2, :around_after2,
         :rollback2c,
         :rollback2b,
-        :rollback2a,
+        :rollback2a
       ])
     end
 
@@ -819,7 +819,7 @@ describe "Integration" do
         :around_before3,
         :rollback2c,
         :rollback2b,
-        :rollback2a,
+        :rollback2a
       ])
     end
   end
@@ -870,7 +870,7 @@ describe "Integration" do
         :around_before3,
         :rollback2c,
         :rollback2b,
-        :rollback2a,
+        :rollback2a
       ])
     end
 
@@ -924,7 +924,7 @@ describe "Integration" do
         :around_before3, :before3,
         :rollback2c,
         :rollback2b,
-        :rollback2a,
+        :rollback2a
       ])
     end
   end
@@ -975,7 +975,7 @@ describe "Integration" do
         :around_before3, :before3,
         :rollback2c,
         :rollback2b,
-        :rollback2a,
+        :rollback2a
       ])
     end
 
@@ -1030,7 +1030,7 @@ describe "Integration" do
         :rollback3,
         :rollback2c,
         :rollback2b,
-        :rollback2a,
+        :rollback2a
       ])
     end
   end
@@ -1082,7 +1082,7 @@ describe "Integration" do
         :rollback3,
         :rollback2c,
         :rollback2b,
-        :rollback2a,
+        :rollback2a
       ])
     end
 
@@ -1137,7 +1137,7 @@ describe "Integration" do
         :rollback3,
         :rollback2c,
         :rollback2b,
-        :rollback2a,
+        :rollback2a
       ])
     end
   end
@@ -1189,7 +1189,7 @@ describe "Integration" do
         :rollback3,
         :rollback2c,
         :rollback2b,
-        :rollback2a,
+        :rollback2a
       ])
     end
 
@@ -1247,7 +1247,7 @@ describe "Integration" do
         :rollback3,
         :rollback2c,
         :rollback2b,
-        :rollback2a,
+        :rollback2a
       ])
     end
   end
@@ -1300,7 +1300,7 @@ describe "Integration" do
         :rollback3,
         :rollback2c,
         :rollback2b,
-        :rollback2a,
+        :rollback2a
       ])
     end
 
@@ -1359,7 +1359,7 @@ describe "Integration" do
         :rollback3,
         :rollback2c,
         :rollback2b,
-        :rollback2a,
+        :rollback2a
       ])
     end
   end
@@ -1415,7 +1415,7 @@ describe "Integration" do
         :rollback3,
         :rollback2c,
         :rollback2b,
-        :rollback2a,
+        :rollback2a
       ])
     end
 
@@ -1474,7 +1474,7 @@ describe "Integration" do
         :rollback3,
         :rollback2c,
         :rollback2b,
-        :rollback2a,
+        :rollback2a
       ])
     end
   end
@@ -1530,7 +1530,7 @@ describe "Integration" do
         :rollback3,
         :rollback2c,
         :rollback2b,
-        :rollback2a,
+        :rollback2a
       ])
     end
 
@@ -1590,7 +1590,7 @@ describe "Integration" do
         :rollback3,
         :rollback2c,
         :rollback2b,
-        :rollback2a,
+        :rollback2a
       ])
     end
   end
@@ -1647,7 +1647,7 @@ describe "Integration" do
         :rollback3,
         :rollback2c,
         :rollback2b,
-        :rollback2a,
+        :rollback2a
       ])
     end
 
@@ -1707,7 +1707,7 @@ describe "Integration" do
         :rollback3,
         :rollback2c,
         :rollback2b,
-        :rollback2a,
+        :rollback2a
       ])
     end
   end
@@ -1764,7 +1764,7 @@ describe "Integration" do
         :rollback3,
         :rollback2c,
         :rollback2b,
-        :rollback2a,
+        :rollback2a
       ])
     end
 

--- a/spec/interactor/context_spec.rb
+++ b/spec/interactor/context_spec.rb
@@ -144,11 +144,9 @@ module Interactor
       end
 
       it "makes the context available from the failure" do
-        begin
-          context.fail!
-        rescue Failure => error
-          expect(error.context).to eq(context)
-        end
+        context.fail!
+      rescue Failure => error
+        expect(error.context).to eq(context)
       end
     end
 

--- a/spec/interactor/hooks_spec.rb
+++ b/spec/interactor/hooks_spec.rb
@@ -43,7 +43,7 @@ module Interactor
           expect(hooked.process).to eq([
             :around_before,
             :process,
-            :around_after,
+            :around_after
           ])
         end
       end
@@ -63,7 +63,7 @@ module Interactor
           expect(hooked.process).to eq([
             :around_before,
             :process,
-            :around_after,
+            :around_after
           ])
         end
       end
@@ -93,7 +93,7 @@ module Interactor
             :around_before2,
             :process,
             :around_after2,
-            :around_after1,
+            :around_after1
           ])
         end
       end
@@ -125,7 +125,7 @@ module Interactor
             :around_before2,
             :process,
             :around_after2,
-            :around_after1,
+            :around_after1
           ])
         end
       end
@@ -146,7 +146,7 @@ module Interactor
         it "runs the before hook method" do
           expect(hooked.process).to eq([
             :before,
-            :process,
+            :process
           ])
         end
       end
@@ -163,7 +163,7 @@ module Interactor
         it "runs the before hook block" do
           expect(hooked.process).to eq([
             :before,
-            :process,
+            :process
           ])
         end
       end
@@ -187,7 +187,7 @@ module Interactor
           expect(hooked.process).to eq([
             :before1,
             :before2,
-            :process,
+            :process
           ])
         end
       end
@@ -213,7 +213,7 @@ module Interactor
           expect(hooked.process).to eq([
             :before1,
             :before2,
-            :process,
+            :process
           ])
         end
       end
@@ -234,7 +234,7 @@ module Interactor
         it "runs the after hook method" do
           expect(hooked.process).to eq([
             :process,
-            :after,
+            :after
           ])
         end
       end
@@ -251,7 +251,7 @@ module Interactor
         it "runs the after hook block" do
           expect(hooked.process).to eq([
             :process,
-            :after,
+            :after
           ])
         end
       end
@@ -275,7 +275,7 @@ module Interactor
           expect(hooked.process).to eq([
             :process,
             :after2,
-            :after1,
+            :after1
           ])
         end
       end
@@ -301,7 +301,7 @@ module Interactor
           expect(hooked.process).to eq([
             :process,
             :after2,
-            :after1,
+            :after1
           ])
         end
       end
@@ -349,7 +349,7 @@ module Interactor
             :after2,
             :after1,
             :around_after2,
-            :around_after1,
+            :around_after1
           ])
         end
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,4 +5,4 @@ end
 
 require "interactor"
 
-Dir[File.expand_path("../support/*.rb", __FILE__)].each { |f| require f }
+Dir[File.expand_path("../support/*.rb", __FILE__)].sort.each { |f| require f }


### PR DESCRIPTION
### Updates

1. Removing from the build those Ruby versions that reached EOL
2. Linting codebase according to Ruby >= 2.5
3. Changing `standardrb` target to 2.5

### Why?

- The codebase is linted to versions that reached EOL, which makes the pipeline fail with Ruby >= 2.5