### PR TITLE
Adds support for ruby 3.0 pattern matching

### DIFF
--- a/lib/interactor/context.rb
+++ b/lib/interactor/context.rb
@@ -177,5 +177,17 @@ module Interactor
     def _called
       @called ||= []
     end
+
+    # Internal: Support for ruby 3.0 pattern matching
+    #
+    # Examples
+    #
+    #   context = MyInteractor.call(foo: "bar")
+    #   # => #<Interactor::Context foo="bar">
+    #   context => { foo: }
+    #   assert(foo == "bar")
+    def deconstruct_keys(keys)
+      to_h
+    end
   end
 end

--- a/lib/interactor/context.rb
+++ b/lib/interactor/context.rb
@@ -183,9 +183,21 @@ module Interactor
     # Examples
     #
     #   context = MyInteractor.call(foo: "bar")
+    #
     #   # => #<Interactor::Context foo="bar">
     #   context => { foo: }
-    #   assert(foo == "bar")
+    #   foo == "bar"
+    #   # => true
+    #
+    #
+    #   case context
+    #   in success: true, result: { first:, second: }
+    #     do_stuff(first, second)
+    #   in failure: true, error_message:
+    #     log_error(message: error_message)
+    #   end
+    #
+    # Returns the context as a hash, including success and failure
     def deconstruct_keys(keys)
       to_h.merge(
         success: success?,

--- a/lib/interactor/context.rb
+++ b/lib/interactor/context.rb
@@ -187,7 +187,10 @@ module Interactor
     #   context => { foo: }
     #   assert(foo == "bar")
     def deconstruct_keys(keys)
-      to_h
+      to_h.merge(
+        success: success?,
+        failure: failure?
+      )
     end
   end
 end

--- a/spec/interactor/context_spec.rb
+++ b/spec/interactor/context_spec.rb
@@ -203,17 +203,15 @@ module Interactor
     describe '#deconstruct_keys' do
       let(:context) { Context.build(foo: :bar) }
 
-      it 'deconstructs as hash pattern' do
-        context => { foo: }
+      let(:deconstructed) { context.deconstruct_keys([:foo, :success, :failure]) }
 
-        expect(foo).to eq(:bar)
+      it 'deconstructs as hash pattern' do
+        expect(deconstructed[:foo]).to eq(:bar)
       end
 
       it 'includes success and failure' do
-        context => { success:, failure: }
-
-        expect(success).to be(true)
-        expect(failure).to be(false)
+        expect(deconstructed[:success]).to eq(true)
+        expect(deconstructed[:failure]).to eq(false)
       end
     end
   end

--- a/spec/interactor/context_spec.rb
+++ b/spec/interactor/context_spec.rb
@@ -208,6 +208,13 @@ module Interactor
 
         expect(foo).to eq(:bar)
       end
+
+      it 'includes success and failure' do
+        context => { success:, failure: }
+
+        expect(success).to be(true)
+        expect(failure).to be(false)
+      end
     end
   end
 end

--- a/spec/interactor/context_spec.rb
+++ b/spec/interactor/context_spec.rb
@@ -199,5 +199,15 @@ module Interactor
         expect(context._called).to eq([])
       end
     end
+
+    describe '#deconstruct_keys' do
+      let(:context) { Context.build(foo: :bar) }
+
+      it 'deconstructs as hash pattern' do
+        context => { foo: }
+
+        expect(foo).to eq(:bar)
+      end
+    end
   end
 end


### PR DESCRIPTION
This is simply done by implementing `deconstruct_keys` in the context, and will enable one to use interactors like this:

```
context = MyInteractor.()

case context
in success: true, result: { first:, second: }
  do_stuff(first, second)
in failure: true, error_message:
  log_error(message: error_message)
end
```

More about pattern matching:
https://docs.ruby-lang.org/en/3.0.0/doc/syntax/pattern_matching_rdoc.html

Obligatory gif:

![](https://c.tenor.com/sfdOLm-uXQAAAAAC/pbj-peanut-butter.gif)
