### PR TITLE
Add default error code to render calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ class SessionsController < ApplicationController
       redirect_to user
     else
       flash.now[:message] = "Please try again."
-      render :new
+      render :new, status: :unprocessable_entity
     end
   end
 
@@ -277,7 +277,7 @@ class SessionsController < ApplicationController
       redirect_to result.user
     else
       flash.now[:message] = t(result.message)
-      render :new
+      render :new, status: :unprocessable_entity
     end
   end
 


### PR DESCRIPTION
Rails 7 adds error codes to validation errors, updated to match rails defaults https://github.com/rails/rails/commit/e83d7dcb2fc98fea3d726fde569001e400a050b1