### PR TITLE
Add passing context between interactors

### DIFF
--- a/lib/interactor/context.rb
+++ b/lib/interactor/context.rb
@@ -121,7 +121,7 @@ module Interactor
     #
     # Raises Interactor::Failure initialized with the Interactor::Context.
     def fail!(context = {})
-      context.each { |key, value| self[key.to_sym] = value }
+      context.to_h.each_pair { |key, value| self[key.to_sym] = value }
       @failure = true
       raise Failure, self
     end

--- a/spec/interactor/context_spec.rb
+++ b/spec/interactor/context_spec.rb
@@ -148,6 +148,13 @@ module Interactor
       rescue Failure => error
         expect(error.context).to eq(context)
       end
+
+      it "passes context between interactors" do
+        sub_context = Context.build(bar: 'foo')
+        context.fail!(sub_context)
+      rescue Failure => error
+        expect(context.bar).to eq('foo')
+      end
     end
 
     describe "#called!" do


### PR DESCRIPTION
## Problem

I have an interactor that calls another interactor. So the situation is:
```ruby
class MainInteractor
  def call
     ...
     result = SubInteractor.call(foo1: 'bar1', foo2: 'bar2', foo3: 'bar3')
     if result. failure?
         context.fail!(foo1: result.foo1, foo2: result.foo2, foo3: result.foo3) # or context.fail!(result.to_h)
     else
        ...
     end
     ...
  end
end
```

It is so annoying to write `result.to_h` all time and looks dirty in the service.

## Aprouch

Instead of passing the result by key/value or hash. I suggest parsing `context={}` to Hash. It helps to pass failed context between interactors.

## Proc and Cons

Proc:
1. In the situation when the interactor has two or more levels of subcontractors. This is easy to pass a failed context and push it to the top.

Cons:
1. If you pass context all time, result context of top-level interactor will contain a lot of context attributes from all sub-interactors.


 