### PR TITLE
RFC: Nested failures fail, not raise

### DIFF
--- a/lib/interactor.rb
+++ b/lib/interactor.rb
@@ -115,8 +115,9 @@ module Interactor
     run!
   rescue Failure => e
     if context.object_id != e.context.object_id
-      raise
+      @context = e.context
     end
+    @context.failure = true
   end
 
   # Internal: Invoke an Interactor instance along with all defined hooks. The

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -929,6 +929,30 @@ describe "Integration" do
     end
   end
 
+  context "when a nested call! fails in an interactor" do
+    let(:interactor3) {
+      build_interactor do
+        class NestedInteractor
+          include Interactor
+
+          def call
+            context.fail!(something: :went_wrong)
+          end
+        end
+
+        def call
+          NestedInteractor.call!
+        end
+      end
+    }
+
+    it 'sets the failure status on enclosing interactor' do
+      result = interactor3.call
+
+      expect(result.failure?).to eq(true)
+    end
+  end
+
   context "when a nested call errors" do
     let(:interactor3) {
       build_interactor do

--- a/spec/support/lint.rb
+++ b/spec/support/lint.rb
@@ -78,14 +78,6 @@ shared_examples :lint do
       }.not_to raise_error
     end
 
-    it "raises other failures" do
-      expect(instance).to receive(:run!).and_raise(Interactor::Failure.new(Interactor::Context.new))
-
-      expect {
-        instance.run
-      }.to raise_error(Interactor::Failure)
-    end
-
     it "raises other errors" do
       expect(instance).to receive(:run!).and_raise("foo")
 


### PR DESCRIPTION
We've been using this library for years, but only recently started adopting `call!` for fast failures.

We found that the behavior of a nested `call!` vs a `fail!` was surprising.

E.g.

```ruby
class SomeInteractor
  include Interactor
  
  def call
    context.fail!
  end
end

SomeInteractor.tap(&:call).failure?

# => true
```

But,

```
class NestedInteractor
  include Interactor
  
  def call
    context.fail!
  end
end

class SomeInteractor
  include Interactor
  
  def call
    NestedInteractor.call!
  end
end

SomeInteractor.tap(&call).failure?
# raises Interactor::Failure exception
```

We would have expected that `SomeInteractor.call` shows the same behavior in both cases, catching `Failure` and returning a context with failure status.

I've attached a (very rough) example implementation in this PR.