### PR TITLE
Update docs, comments to nudge timing with monotonic clock

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,9 +129,9 @@ will continue invocation of the interactor. For example, with a block:
 
 ```ruby
 around do |interactor|
-  context.start_time = Time.now
+  context.start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
   interactor.call
-  context.finish_time = Time.now
+  context.finish_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 end
 ```
 
@@ -141,9 +141,9 @@ With a method:
 around :time_execution
 
 def time_execution(interactor)
-  context.start_time = Time.now
+  context.start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
   interactor.call
-  context.finish_time = Time.now
+  context.finish_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 end
 ```
 
@@ -209,9 +209,9 @@ module InteractorTimer
 
   included do
     around do |interactor|
-      context.start_time = Time.now
+      context.start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       interactor.call
-      context.finish_time = Time.now
+      context.finish_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     end
   end
 end

--- a/lib/interactor/hooks.rb
+++ b/lib/interactor/hooks.rb
@@ -41,9 +41,9 @@ module Interactor
       #     private
       #
       #     def time_execution(interactor)
-      #       context.start_time = Time.now
+      #       context.start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       #       interactor.call
-      #       context.finish_time = Time.now
+      #       context.finish_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       #     end
       #   end
       #
@@ -80,7 +80,7 @@ module Interactor
       #     private
       #
       #     def set_start_time
-      #       context.start_time = Time.now
+      #       context.start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       #     end
       #   end
       #
@@ -117,7 +117,7 @@ module Interactor
       #     private
       #
       #     def set_finish_time
-      #       context.finish_time = Time.now
+      #       context.finish_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       #     end
       #   end
       #


### PR DESCRIPTION
## What

Update docs and comments to encourage people to use the monotonic clock.

## Why

The docs and comments show use of `Time.now` for timing interactor descendants. However, `Time.now` can suffer from "discontinuous jumps" that are solved by using the system's monotonic clock.<sup>[1](https://blog.dnsimple.com/2018/03/elapsed-time-with-ruby-the-right-way/)</sup>