### PR TITLE
Fix typo on code comment re: "organize" method

### DIFF
--- a/lib/interactor/organizer.rb
+++ b/lib/interactor/organizer.rb
@@ -8,7 +8,7 @@ module Interactor
   #   class MyOrganizer
   #     include Interactor::Organizer
   #
-  #     organizer InteractorOne, InteractorTwo
+  #     organize InteractorOne, InteractorTwo
   #   end
   module Organizer
     # Internal: Install Interactor::Organizer's behavior in the given class.


### PR DESCRIPTION
I believe this comment is supposed to describe calling the `organize` method rather than `organizer`.