### PR TITLE
Add ostruct dependency to gemspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 3.2.0 / Unreleased
 * [BUGFIX] Raise failures from nested contexts [#170]
+* [FEATURE] Add `ostruct` dependency to gemspec.
 
 ## 3.1.2 / 2019-12-29
 * [BUGFIX] Fix Context#fail! on Ruby 2.7

--- a/interactor.gemspec
+++ b/interactor.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |spec|
   spec.files = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
   spec.test_files = spec.files.grep(/^spec/)
 
+  spec.add_dependency "ostruct"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
 end


### PR DESCRIPTION
`ostruct` is loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.