### PR TITLE
Add success method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * [BUGFIX] Raise failures from nested contexts [#170]
 * [FEATURE] Add `ostruct` dependency to gemspec.
 * [FEATURE] Add support for Ruby 3 pattern matching on the Context [#200]
+* [FEATURE] Add `success!` method to Context for early successful completion
 
 ## 3.1.2 / 2019-12-29
 * [BUGFIX] Fix Context#fail! on Ruby 2.7

--- a/lib/interactor.rb
+++ b/lib/interactor.rb
@@ -72,6 +72,7 @@ module Interactor
     # Returns the resulting Interactor::Context after manipulation by the
     #   interactor.
     # Raises Interactor::Failure if the context is failed.
+    # Raises Interactor::Success if the context is succeeded.
     def call!(context = {})
       new(context).tap(&:run!).context
     end
@@ -113,7 +114,7 @@ module Interactor
   # Returns nothing.
   def run
     run!
-  rescue Failure => e
+  rescue Failure, Success => e
     if context.object_id != e.context.object_id
       raise
     end

--- a/lib/interactor/context.rb
+++ b/lib/interactor/context.rb
@@ -130,6 +130,34 @@ module Interactor
       raise Failure, self
     end
 
+    # Public: Success the Interactor::Context. Succeeding a context raises an error
+    # that may be rescued by the calling interactor. The context is also flagged
+    # as having succeeded.
+    #
+    # Optionally the caller may provide a hash of key/value pairs to be merged
+    # into the context before success.
+    #
+    # context - A Hash whose key/value pairs are merged into the existing
+    #           Interactor::Context instance. (default: {})
+    #
+    # Examples
+    #
+    #   context = Interactor::Context.new
+    #   # => #<Interactor::Context>
+    #   context.success!
+    #   # => Interactor::Success: #<Interactor::Context>
+    #   context.success! rescue false
+    #   # => false
+    #   context.success!(foo: "baz")
+    #   # => Interactor::Success: #<Interactor::Context foo="baz">
+    #
+    # Raises Interactor::Success initialized with the Interactor::Context.
+    def success!(context = {})
+      context.each { |key, value| self[key.to_sym] = value }
+      @failure = false
+      raise Success, self
+    end
+
     # Internal: Track that an Interactor has been called. The "called!" method
     # is used by the interactor being invoked with this context. After an
     # interactor is successfully called, the interactor instance is tracked in

--- a/lib/interactor/error.rb
+++ b/lib/interactor/error.rb
@@ -28,4 +28,34 @@ module Interactor
       super
     end
   end
+
+  # Internal: Error raised during Interactor::Context success. The error stores
+  # a copy of the successful context for debugging purposes.
+  class Success < StandardError
+    # Internal: Gets the Interactor::Context of the Interactor::Success
+    # instance.
+    attr_reader :context
+
+    # Internal: Initialize an Interactor::Success.
+    #
+    # context - An Interactor::Context to be stored within the
+    #           Interactor::Success instance. (default: nil)
+    #
+    # Examples
+    #
+    #   Interactor::Success.new
+    #   # => #<Interactor::Success: Interactor::Success>
+    #
+    #   context = Interactor::Context.new(foo: "bar")
+    #   # => #<Interactor::Context foo="bar">
+    #   Interactor::Success.new(context)
+    #   # => #<Interactor::Success: #<Interactor::Context foo="bar">>
+    #
+    #   raise Interactor::Success, context
+    #   # => Interactor::Success: #<Interactor::Context foo="bar">
+    def initialize(context = nil)
+      @context = context
+      super
+    end
+  end
 end

--- a/spec/interactor/context_spec.rb
+++ b/spec/interactor/context_spec.rb
@@ -152,6 +152,24 @@ module Interactor
       end
     end
 
+    describe "#success!" do
+      let(:context) { Context.build(foo: "bar") }
+
+      it "raises success" do
+        expect {
+          context.success!
+        }.to raise_error(Success)
+      end
+
+      it "makes the context available from the success" do
+        begin
+          context.success!
+        rescue Success => error
+          expect(error.context).to eq(context)
+        end
+      end
+    end
+
     describe "#called!" do
       let(:context) { Context.build }
       let(:instance1) { double(:instance1) }


### PR DESCRIPTION
# Add success! method to Context

This PR adds a `success!` method to `Interactor::Context`, providing a symmetrical counterpart to the existing `fail!` method. This allows interactors to complete successfully and exit early when certain conditions are met.

## Problem

Currently, interactors can only exit early using `context.fail!`, which marks the context as failed. There's no built-in way to exit early with a successful result, forcing developers to either:
- Continue processing even when early completion is desired
- Use `fail!` for successful early exits (which is semantically incorrect)

## Solution

Add `context.success!` method that:
- Completes the interactor successfully
- Exits early from the current step
- Optionally updates the context with additional data
- Raises `Interactor::Success` exception (handled by the framework)

### Basic Usage
```ruby
def call
  if context.data.empty?
    context.success!(result: "No data to process")
  end
  
  # Process data only if not empty
  context.result = process_data(context.data)
end
```

### With Context Updates
```ruby
def call
  if context.user.admin?
    context.success!(message: "Admin access granted", bypass_checks: true)
  end
  
  # Regular processing for non-admin users
  perform_regular_checks
end
```

### In Organizers
```ruby
class ProcessOrder
  include Interactor::Organizer
  
  organize ValidateOrder, ProcessPayment, SendConfirmation
end

# If ValidateOrder calls context.success!, the organizer stops
# and returns the successful context without running remaining steps
```

## GIF Requirement

![](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExZnd4Y2NkOW53YWN6NGY5d3VzdGNocTdjejNnbXdmNjZpNDB1dXY3NSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/Cyv99H3tH0y1PVYPB1/giphy.gif)

---

This feature follows the same patterns as the existing `fail!` method, ensuring consistency and familiarity for developers already using the Interactor gem.