### PR TITLE
Replace OpenStruct with hash-backed Context (v4.0.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 4.0.0 / 2026-03-06
+
+* [BREAKING] Replace `OpenStruct` with a plain hash-backed `Context` implementation.
+  `Interactor::Context` no longer inherits from `OpenStruct`. All documented public
+  API (`context.foo`, `context.foo = value`, `[]`, `[]=`, `to_h`, `fail!`, `success?`,
+  `failure?`, `rollback!`, `deconstruct_keys`) is fully preserved.
+
+  **Migration:** If your code checks `context.is_a?(OpenStruct)`, or calls OpenStruct
+  methods not part of the Interactor API (`each_pair`, `marshal_dump`, etc.), update
+  those callsites. Otherwise, no changes are required.
+
+* [ENHANCEMENT] Remove `ostruct` runtime dependency — no gem dependency required.
+
 ## 3.2.0 / 2025-07-10
 * [BUGFIX] Raise failures from nested contexts [#170]
 * [FEATURE] Add `ostruct` dependency to gemspec.

--- a/interactor.gemspec
+++ b/interactor.gemspec
@@ -2,7 +2,7 @@ require "English"
 
 Gem::Specification.new do |spec|
   spec.name = "interactor"
-  spec.version = "3.2.0"
+  spec.version = "4.0.0"
 
   spec.author = "Collective Idea"
   spec.email = "info@collectiveidea.com"
@@ -13,7 +13,6 @@ Gem::Specification.new do |spec|
 
   spec.files = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
 
-  spec.add_dependency "ostruct"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
 end

--- a/lib/interactor.rb
+++ b/lib/interactor.rb
@@ -114,9 +114,7 @@ module Interactor
   def run
     run!
   rescue Failure => e
-    if context.object_id != e.context.object_id
-      raise
-    end
+    raise unless context.equal?(e.context)
   end
 
   # Internal: Invoke an Interactor instance along with all defined hooks. The

--- a/lib/interactor/context.rb
+++ b/lib/interactor/context.rb
@@ -1,5 +1,3 @@
-require "ostruct"
-
 module Interactor
   # Public: The object for tracking state of an Interactor's invocation. The
   # context is used to initialize the interactor with the information required
@@ -28,7 +26,7 @@ module Interactor
   #   # => "baz"
   #   context
   #   # => #<Interactor::Context foo="baz" hello="world">
-  class Context < OpenStruct
+  class Context
     # Internal: Initialize an Interactor::Context or preserve an existing one.
     # If the argument given is an Interactor::Context, the argument is returned.
     # Otherwise, a new Interactor::Context is initialized from the provided
@@ -58,6 +56,68 @@ module Interactor
       else
         new(context)
       end
+    end
+
+    # Internal: Initialize an Interactor::Context from a Hash of key/value
+    # pairs. Keys are stored as symbols.
+    #
+    # data - A Hash whose key/value pairs populate the context. (default: {})
+    #
+    # Returns nothing.
+    def initialize(data = {})
+      @table = {}
+      data.to_h.each { |k, v| @table[k.to_sym] = v }
+    end
+
+    # Internal: Read a value from the context by key.
+    #
+    # key - A Symbol or String key.
+    #
+    # Returns the stored value or nil.
+    def [](key)
+      @table[key.to_sym]
+    end
+
+    # Internal: Write a value into the context by key.
+    #
+    # key   - A Symbol or String key.
+    # value - The value to store.
+    #
+    # Returns the value.
+    def []=(key, value)
+      @table[key.to_sym] = value
+    end
+
+    # Public: Return the context as a plain Hash.
+    #
+    # Returns a Hash.
+    def to_h
+      @table.dup
+    end
+
+    # Public: Equality check based on stored attributes.
+    #
+    # other - Another object to compare.
+    #
+    # Returns true if both are a Context with identical attributes.
+    def ==(other)
+      other.is_a?(self.class) && other.to_h == to_h
+    end
+
+    # Internal: Human-readable representation of the context.
+    #
+    # Returns a String.
+    def inspect
+      pairs = @table.map { |k, v| "#{k}=#{v.inspect}" }.join(", ")
+      pairs.empty? ? "#<#{self.class}>" : "#<#{self.class} #{pairs}>"
+    end
+
+    # Internal: String representation (used as the exception message in
+    # Interactor::Failure).
+    #
+    # Returns a String.
+    def to_s
+      inspect
     end
 
     # Public: Whether the Interactor::Context is successful. By default, a new
@@ -207,6 +267,35 @@ module Interactor
         success: success?,
         failure: failure?
       )
+    end
+
+    private
+
+    # Internal: The underlying hash store.
+    #
+    # Returns a Hash.
+    attr_reader :table
+
+    # Internal: Handle dynamic attribute accessors not defined on the class.
+    #
+    # name - A Symbol method name.
+    # args - Arguments passed to the method.
+    #
+    # Returns the stored value for a getter, or sets and returns the value for
+    #   a setter.
+    def method_missing(name, *args)
+      if (key = name.to_s.chomp!("="))
+        @table[key.to_sym] = args.first
+      else
+        @table[name]
+      end
+    end
+
+    # Internal: All dynamic attribute methods are supported.
+    #
+    # Returns true.
+    def respond_to_missing?(name, include_private = false)
+      true
     end
   end
 end

--- a/spec/interactor/context_spec.rb
+++ b/spec/interactor/context_spec.rb
@@ -1,5 +1,9 @@
 module Interactor
   describe Context do
+    it "inherits directly from Object, not OpenStruct" do
+      expect(Context.superclass).to eq(Object)
+    end
+
     describe ".build" do
       it "converts the given hash to a context" do
         context = Context.build(foo: "bar")
@@ -12,7 +16,7 @@ module Interactor
         context = Context.build
 
         expect(context).to be_a(Context)
-        expect(context.send(:table)).to eq({})
+        expect(context.to_h).to eq({})
       end
 
       it "doesn't affect the original hash" do


### PR DESCRIPTION
## Summary

- Replaces `Interactor::Context < OpenStruct` with a plain hash-backed implementation
- Removes the `ostruct` runtime dependency entirely
- Bumps version to `4.0.0` (semver major — breaking change)

## Motivation

`OpenStruct` was deprecated in Ruby 3.2+ and may be removed in a future Ruby version. This change eliminates the deprecation warning and future-proofs the gem with zero runtime dependencies.

## What changed

**`lib/interactor/context.rb`**
- `Context` now inherits from `Object` instead of `OpenStruct`
- Hash-backed `@table` store with `method_missing` for dynamic accessors
- Implements `[]`, `[]=`, `to_h`, `==`, `inspect`, `to_s` explicitly
- Compatible with Ruby 1.9+ (no `transform_keys`, uses plain `Hash#each`)

**`interactor.gemspec`**
- Removed `spec.add_dependency "ostruct"`
- Version bumped to `4.0.0`

**`lib/interactor.rb`**
- Fixed pre-existing StandardRB `Lint/IdentityComparison` warning (`object_id !=` → `!equal?`)

**`spec/interactor/context_spec.rb`**
- Added spec asserting `Context.superclass == Object` to lock in the new contract
- Updated `send(:table)` internal accessor test to use public `to_h`

## Breaking changes

- `context.is_a?(OpenStruct)` now returns `false`
- OpenStruct-only methods (`each_pair`, `marshal_dump`, `marshal_load`) are no longer available

**Migration:** If your code does not check `is_a?(OpenStruct)` or call OpenStruct-specific methods, no changes are required.

## Test results

```
111 examples, 0 failures
StandardRB: no offenses
```